### PR TITLE
fix: align SKILL.md description with quality standard

### DIFF
--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coach
-description: "Use when Claude makes repeated mistakes, users correct behavior, tool failures indicate missing knowledge, or reviewing learning candidates via /coach commands."
+description: "Use when Claude makes repeated mistakes, users correct behavior, tool failures indicate missing knowledge, or managing learning via /coach commands."
 ---
 
 # Coach - Self-Improving Learning System


### PR DESCRIPTION
## Summary
- Fix SKILL.md description to use "Use when..." trigger format
- Remove "Agent Skill:" prefix and "By Netresearch." suffix
- Remove workflow summaries from description

Addresses netresearch/claude-code-marketplace#32