### PR TITLE
feat: detect process violations (squash, cache-path, premature success)

### DIFF
--- a/references/signal_patterns.md
+++ b/references/signal_patterns.md
@@ -130,6 +130,7 @@ ImportError         # Python import error
 | Signal Type | Priority | Min Confidence |
 |-------------|----------|----------------|
 | COMMAND_FAILURE | 100 | 0.85 |
+| PROCESS_VIOLATION | 90 | 0.70 |
 | USER_CORRECTION | 80 | 0.50 |
 | REPETITION | 60 | 0.40 |
 | TONE_ESCALATION | 40 | 0.20 |
@@ -139,6 +140,61 @@ ImportError         # Python import error
 | Signal Type | Min Evidence | Notes |
 |-------------|--------------|-------|
 | COMMAND_FAILURE | 1 | Single failure is high-signal |
+| PROCESS_VIOLATION | 1 | Each violation is high-signal; aggregator clusters by `kind` |
 | USER_CORRECTION | 2 | Need pattern, not one-off |
 | REPETITION | 3 | Need clear repetition pattern |
 | TONE_ESCALATION | N/A | Triggers review only |
+
+## Process Violation Patterns
+
+`PROCESS_VIOLATION` detects Claude's own breaches of project workflow rules — unlike USER_CORRECTION (user reaction) or COMMAND_FAILURE (tool reaction), these fire on Claude's actions directly.
+
+### Kind: `unauthorized_squash`
+
+Triggered when Claude runs a squash-merge command. Project default is atomic commits; repo-specific overrides live in the aggregator.
+
+```regex
+\bgh\s+pr\s+merge\b[^\n]*--squash\b
+\bgit\s+merge\s+--squash\b
+\bgit\s+rebase\b[^\n]*-i\b[^\n]*\bsquash\b
+```
+
+### Kind: `cache_path_edit`
+
+Triggered when Write/Edit/MultiEdit targets an installed cache or bare-repo path. These edits are silently clobbered on next marketplace update.
+
+```regex
+[/~]\.claude/skills/
+[/~]\.claude/plugins/cache/
+[/~]\.claude/plugins/marketplaces/
+/\.bare/
+/\.bare$
+```
+
+### Kind: `premature_success_claim`
+
+Triggered when assistant text declares pass/tested/verified and the same turn has no preceding tool output. Phrases:
+
+```regex
+\b(?:all\s+)?tests?\s+pass(?:ed|ing)?\b
+\ball\s+green\b
+\bverified\b
+\btested\s+and\s+working\b
+\bconfirmed\s+working\b
+\bshould\s+work\s+now\b
+\btry\s+(?:it\s+)?again\b
+```
+
+### Detection Hook Points
+
+| Kind | Phase | Input |
+|------|-------|-------|
+| unauthorized_squash | PostToolUse on Bash | `tool_input.command` |
+| cache_path_edit | PreToolUse on Write/Edit/MultiEdit | `tool_input.file_path` |
+| premature_success_claim | Stop / assistant message | assistant text + preceding tool outputs in same turn |
+
+### False-Positive Notes
+
+- Squash is legitimate on repos that use squash-merge. Aggregator should read the repo's merge policy (GitHub API `allow_squash_merge` + project convention) before promoting violations.
+- Cache-path patterns also match read-only paths; only Write/Edit/MultiEdit tool-names should feed this detector.
+- Success-claim patterns fire on questions too ("should this work now?"); only assistant declarative messages should feed this detector.

--- a/references/signal_patterns.md
+++ b/references/signal_patterns.md
@@ -187,14 +187,22 @@ Triggered when assistant text declares pass/tested/verified and the same turn ha
 
 ### Detection Hook Points
 
-| Kind | Phase | Input |
-|------|-------|-------|
-| unauthorized_squash | PostToolUse on Bash | `tool_input.command` |
-| cache_path_edit | PreToolUse on Write/Edit/MultiEdit | `tool_input.file_path` |
-| premature_success_claim | Stop / assistant message | assistant text + preceding tool outputs in same turn |
+All three kinds are surfaced via `scripts/detect_signals.py`. The `--phase` flag selects how the payload is interpreted:
+
+| Kind | Script invocation | Input JSON (stdin) |
+|------|-------------------|--------------------|
+| unauthorized_squash | `detect_signals.py --phase tool --from-stdin` (PostToolUse on Bash) | `{"tool_name":"Bash","tool_input":{"command":"..."},"tool_result":{...}}` |
+| cache_path_edit | `detect_signals.py --phase tool --from-stdin` (PostToolUse on Write/Edit/MultiEdit) | `{"tool_name":"Write","tool_input":{"file_path":"..."},"tool_result":{...}}` |
+| premature_success_claim | `detect_signals.py --phase stop --from-stdin` (Stop hook) | `{"assistant_text":"...","turn_tool_outputs":[...]}` or `{"has_preceding_tool_output":true/false}` |
+
+The `unauthorized_squash` and `cache_path_edit` checks are wired into `process_tool_result()` and fire automatically on any `tool`-phase invocation. The `premature_success_claim` check needs the whole assistant turn plus a boolean for same-turn tool output — information not present on a per-tool-call PostToolUse payload — so it runs through the dedicated `stop` phase.
+
+### Aggregator Status
+
+`PROCESS_VIOLATION` events are stored in the events database via the standard `store_signal()` path (no schema change — it's a new `signal_type` on the existing `events` table). The aggregator (`scripts/aggregate.py`) currently passes unknown signal types through as generic candidates; it doesn't yet have PROCESS_VIOLATION-specific clustering. A follow-up can add dedicated aggregation (e.g. cluster `cache_path_edit` across sessions by target path, or suppress `unauthorized_squash` on repos whose `allow_squash_merge` is true). Until that lands, these events are visible in the raw events DB and surface through `/coach review` proposals.
 
 ### False-Positive Notes
 
-- Squash is legitimate on repos that use squash-merge. Aggregator should read the repo's merge policy (GitHub API `allow_squash_merge` + project convention) before promoting violations.
-- Cache-path patterns also match read-only paths; only Write/Edit/MultiEdit tool-names should feed this detector.
-- Success-claim patterns fire on questions too ("should this work now?"); only assistant declarative messages should feed this detector.
+- Squash is legitimate on repos that use squash-merge. Aggregator should read the repo's merge policy (GitHub API `allow_squash_merge` + project convention) before promoting violations — the detector flags unconditionally on purpose, with the filter in the aggregator.
+- Cache-path patterns also match read-only paths; the `tool_name in {Write, Edit, MultiEdit}` check inside `detect_process_violation` prevents false-positives from Read/Glob/Grep.
+- Success-claim patterns match question forms too ("should this work now?" contains `should work now`); the Stop-phase invocation only fires on assistant messages, so question-form triggers on user text are avoided by routing.

--- a/scripts/detect_signals.py
+++ b/scripts/detect_signals.py
@@ -35,7 +35,7 @@ class SignalDetector:
 
     SIGNAL_TYPES = {
         "COMMAND_FAILURE": 100,  # Priority weight
-        "PROCESS_VIOLATION": 90, # Claude broke a project workflow rule (squash/cache/unverified)
+        "PROCESS_VIOLATION": 90,  # Claude broke a project workflow rule (squash/cache/unverified)
         "USER_CORRECTION": 80,
         "SKILL_SUPPLEMENT": 75,  # User supplementing a skill with additional info
         "VERIFICATION_QUESTION": 72,  # User asking if something was done (implicit expectation)
@@ -479,11 +479,15 @@ class SignalDetector:
 
         return None
 
-    def detect_process_violation(self, *, command: str = "",
-                                 tool_name: str = "",
-                                 file_path: str = "",
-                                 assistant_text: str = "",
-                                 has_preceding_tool_output: bool = False) -> Optional[Dict]:
+    def detect_process_violation(
+        self,
+        *,
+        command: str = "",
+        tool_name: str = "",
+        file_path: str = "",
+        assistant_text: str = "",
+        has_preceding_tool_output: bool = False,
+    ) -> Optional[Dict]:
         """Detect Claude's own violations of project workflow rules.
 
         Flags three classes: unauthorized squash in git/gh commands, edits
@@ -496,32 +500,38 @@ class SignalDetector:
         if command:
             for pattern in self.patterns.get("unauthorized_squash", []):
                 if pattern.search(command):
-                    violations.append({
-                        "kind": "unauthorized_squash",
-                        "pattern": pattern.pattern,
-                        "command": command[:500],
-                    })
+                    violations.append(
+                        {
+                            "kind": "unauthorized_squash",
+                            "pattern": pattern.pattern,
+                            "command": command[:500],
+                        }
+                    )
 
         # Cache-path edit — check Write/Edit target paths
         if tool_name in ("Write", "Edit", "MultiEdit") and file_path:
             for pattern in self.patterns.get("cache_path_edit", []):
                 if pattern.search(file_path):
-                    violations.append({
-                        "kind": "cache_path_edit",
-                        "pattern": pattern.pattern,
-                        "tool": tool_name,
-                        "file_path": file_path[:500],
-                    })
+                    violations.append(
+                        {
+                            "kind": "cache_path_edit",
+                            "pattern": pattern.pattern,
+                            "tool": tool_name,
+                            "file_path": file_path[:500],
+                        }
+                    )
 
         # Premature success claim — check assistant text without backing output
         if assistant_text and not has_preceding_tool_output:
             for pattern in self.patterns.get("premature_success_claims", []):
                 if pattern.search(assistant_text):
-                    violations.append({
-                        "kind": "premature_success_claim",
-                        "pattern": pattern.pattern,
-                        "snippet": assistant_text[:300],
-                    })
+                    violations.append(
+                        {
+                            "kind": "premature_success_claim",
+                            "pattern": pattern.pattern,
+                            "snippet": assistant_text[:300],
+                        }
+                    )
 
         if violations:
             return {
@@ -597,8 +607,13 @@ class SignalDetector:
         return signals
 
     def process_tool_result(
-        self, exit_code: int, stderr: str, command: str,
-        context: Dict = None, tool_name: str = "", file_path: str = ""
+        self,
+        exit_code: int,
+        stderr: str,
+        command: str,
+        context: Dict = None,
+        tool_name: str = "",
+        file_path: str = "",
     ) -> List[Dict]:
         """Process a tool result for failure signals."""
         signals = []
@@ -620,10 +635,7 @@ class SignalDetector:
             file_path=file_path,
         )
         if violation:
-            signals.append({
-                **violation,
-                "context": context
-            })
+            signals.append({**violation, "context": context})
 
         return signals
 
@@ -737,8 +749,11 @@ def main():
                             stderr = output
 
                     signals = detector.process_tool_result(
-                        exit_code, stderr, command,
-                        tool_name=tool_name, file_path=file_path,
+                        exit_code,
+                        stderr,
+                        command,
+                        tool_name=tool_name,
+                        file_path=file_path,
                     )
 
                 elif args.phase == "pre":

--- a/scripts/detect_signals.py
+++ b/scripts/detect_signals.py
@@ -35,6 +35,7 @@ class SignalDetector:
 
     SIGNAL_TYPES = {
         "COMMAND_FAILURE": 100,  # Priority weight
+        "PROCESS_VIOLATION": 90, # Claude broke a project workflow rule (squash/cache/unverified)
         "USER_CORRECTION": 80,
         "SKILL_SUPPLEMENT": 75,  # User supplementing a skill with additional info
         "VERIFICATION_QUESTION": 72,  # User asking if something was done (implicit expectation)
@@ -174,6 +175,34 @@ class SignalDetector:
                     r"(?:npm|yarn|pnpm)\s+(?:WARN|warn).*(?:deprecated|outdated)",
                     r"pip.*(?:WARNING|warning).*(?:deprecated|outdated)",
                     r"version\s+(\d+\.[\d.]+).*(?:is\s+)?(?:old|outdated|unsupported)",
+                ],
+                # Process violations: Claude breaking project workflow rules.
+                # Detected against the assistant's OWN tool calls / output, not user messages.
+                "unauthorized_squash": [
+                    # Squash merge when project uses atomic commits (flag all squashes;
+                    # aggregator uses repo policy to filter false positives).
+                    r"\bgh\s+pr\s+merge\b[^\n]*--squash\b",
+                    r"\bgit\s+merge\s+--squash\b",
+                    r"\bgit\s+rebase\b[^\n]*-i\b[^\n]*\bsquash\b",
+                ],
+                "cache_path_edit": [
+                    # Write or Edit targeting a known cache/bare path.
+                    r"[/~]\.claude/skills/",
+                    r"[/~]\.claude/plugins/cache/",
+                    r"[/~]\.claude/plugins/marketplaces/",
+                    r"/\.bare/",
+                    r"/\.bare$",
+                ],
+                "premature_success_claims": [
+                    # Assistant text declaring pass/tested/verified. Without backing
+                    # command output in the same turn, aggregator treats as violation.
+                    r"\b(?:all\s+)?tests?\s+pass(?:ed|ing)?\b",
+                    r"\ball\s+green\b",
+                    r"\bverified\b",
+                    r"\btested\s+and\s+working\b",
+                    r"\bconfirmed\s+working\b",
+                    r"\bshould\s+work\s+now\b",
+                    r"\btry\s+(?:it\s+)?again\b",
                 ],
             }
         }
@@ -450,6 +479,59 @@ class SignalDetector:
 
         return None
 
+    def detect_process_violation(self, *, command: str = "",
+                                 tool_name: str = "",
+                                 file_path: str = "",
+                                 assistant_text: str = "",
+                                 has_preceding_tool_output: bool = False) -> Optional[Dict]:
+        """Detect Claude's own violations of project workflow rules.
+
+        Flags three classes: unauthorized squash in git/gh commands, edits
+        targeting known cache/bare paths, and premature success claims in
+        assistant text with no backing tool output in the same turn.
+        """
+        violations = []
+
+        # Unauthorized squash — check Bash commands
+        if command:
+            for pattern in self.patterns.get("unauthorized_squash", []):
+                if pattern.search(command):
+                    violations.append({
+                        "kind": "unauthorized_squash",
+                        "pattern": pattern.pattern,
+                        "command": command[:500],
+                    })
+
+        # Cache-path edit — check Write/Edit target paths
+        if tool_name in ("Write", "Edit", "MultiEdit") and file_path:
+            for pattern in self.patterns.get("cache_path_edit", []):
+                if pattern.search(file_path):
+                    violations.append({
+                        "kind": "cache_path_edit",
+                        "pattern": pattern.pattern,
+                        "tool": tool_name,
+                        "file_path": file_path[:500],
+                    })
+
+        # Premature success claim — check assistant text without backing output
+        if assistant_text and not has_preceding_tool_output:
+            for pattern in self.patterns.get("premature_success_claims", []):
+                if pattern.search(assistant_text):
+                    violations.append({
+                        "kind": "premature_success_claim",
+                        "pattern": pattern.pattern,
+                        "snippet": assistant_text[:300],
+                    })
+
+        if violations:
+            return {
+                "signal_type": "PROCESS_VIOLATION",
+                "violations": violations,
+                "confidence": min(0.7 + (0.1 * len(violations)), 0.95),
+                "preceding_context": self.get_preceding_context(),
+            }
+        return None
+
     def detect_version_issue(self, stderr: str, command: str) -> Optional[Dict]:
         """Detect version/outdated tool issues from command output."""
         matches = []
@@ -515,7 +597,8 @@ class SignalDetector:
         return signals
 
     def process_tool_result(
-        self, exit_code: int, stderr: str, command: str, context: Dict = None
+        self, exit_code: int, stderr: str, command: str,
+        context: Dict = None, tool_name: str = "", file_path: str = ""
     ) -> List[Dict]:
         """Process a tool result for failure signals."""
         signals = []
@@ -529,6 +612,18 @@ class SignalDetector:
             version_issue = self.detect_version_issue(stderr, command)
             if version_issue:
                 signals.append({**version_issue, "context": context})
+
+        # Check for process violations (squash in git/gh, cache-path Write/Edit)
+        violation = self.detect_process_violation(
+            command=command,
+            tool_name=tool_name,
+            file_path=file_path,
+        )
+        if violation:
+            signals.append({
+                **violation,
+                "context": context
+            })
 
         return signals
 
@@ -626,12 +721,14 @@ def main():
                     # Extract from Claude Code hook format
                     tool_result = data.get("tool_result", {})
                     tool_input = data.get("tool_input", {})
+                    tool_name = data.get("tool_name", "")
 
                     exit_code = tool_result.get("exit_code", 0)
                     stderr = tool_result.get("stderr", "") or tool_result.get(
                         "output", ""
                     )
                     command = tool_input.get("command", "")
+                    file_path = tool_input.get("file_path", "")
 
                     # Handle case where output contains error info
                     if not stderr and tool_result.get("output"):
@@ -639,7 +736,10 @@ def main():
                         if "error" in output.lower() or "Error" in output:
                             stderr = output
 
-                    signals = detector.process_tool_result(exit_code, stderr, command)
+                    signals = detector.process_tool_result(
+                        exit_code, stderr, command,
+                        tool_name=tool_name, file_path=file_path,
+                    )
 
                 elif args.phase == "pre":
                     content = data.get("content", "") or data.get("message", "")

--- a/scripts/detect_signals.py
+++ b/scripts/detect_signals.py
@@ -690,9 +690,9 @@ def main():
     parser = argparse.ArgumentParser(description="Detect friction signals")
     parser.add_argument(
         "--phase",
-        choices=["pre", "post", "tool"],
+        choices=["pre", "post", "tool", "stop"],
         required=True,
-        help="Processing phase",
+        help="Processing phase (pre=user, tool=tool result, stop=end of assistant turn)",
     )
     parser.add_argument(
         "--content", type=str, help="Message content (or read from stdin)"
@@ -745,6 +745,28 @@ def main():
                     content = data.get("content", "") or data.get("message", "")
                     if content:
                         signals = detector.process_user_message(content)
+
+                elif args.phase == "stop":
+                    # Stop hook: audit the just-ended assistant turn for
+                    # premature success claims. The hook payload should supply
+                    # the final assistant text and a list of tool outputs
+                    # produced in the same turn; if any tool output is present,
+                    # claims are considered substantiated.
+                    assistant_text = (
+                        data.get("assistant_text", "")
+                        or data.get("content", "")
+                        or data.get("message", "")
+                    )
+                    turn_tool_outputs = data.get("turn_tool_outputs", []) or []
+                    has_output = bool(turn_tool_outputs) or bool(
+                        data.get("has_preceding_tool_output")
+                    )
+                    violation = detector.detect_process_violation(
+                        assistant_text=assistant_text,
+                        has_preceding_tool_output=has_output,
+                    )
+                    if violation:
+                        signals = [violation]
         except json.JSONDecodeError:
             # Not JSON, treat as plain text
             if args.phase == "pre":

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -18,15 +18,7 @@ Coach enables Claude to learn from friction and improve over time. It detects le
 
 ## Activation Triggers
 
-Activate this skill when:
-- User corrects Claude's behavior ("no", "stop", "don't", "I said", "you didn't")
-- Same instruction is repeated within recent turns
-- Tool/command failures occur (non-zero exit, stderr patterns)
-- Tone escalation detected (ALL CAPS, "!!!", "for the last time")
-- User supplements a skill with additional instructions ("the skill doesn't...", "also remember...")
-- Deprecated/outdated tool warnings appear in command output
-- User explicitly requests `/coach` commands
-- Session end triggers batch review of accumulated signals
+Activate when: user corrections ("no", "stop", "don't"), repeated instructions, tool/command failures, tone escalation (ALL CAPS, "!!!"), skill supplements ("also remember..."), deprecated-tool warnings, explicit `/coach` commands, or session end.
 
 ## Signal Categories (Priority Order)
 
@@ -49,12 +41,12 @@ Activate this skill when:
 
 ## Workflow Summary
 
-1. **Signal Detection** - Hooks capture friction events → stored in `~/.claude-coach/events.sqlite`
-2. **Candidate Generation** - Aggregate signals into proposals with fingerprints for deduplication
-3. **Scope Decision** - Determine project vs global scope based on path/language patterns
-4. **Proposal Review** - User reviews via `/coach review`, approves/rejects/edits
-5. **Application** - Approved rules added to CLAUDE.md (project or global)
-6. **Session Retrospective** - `/coach retro` analyzes completed sessions, maps manual work to skill gaps, and creates PRs to improve skills at their source repos
+1. **Detection** — hooks capture events → `~/.claude-coach/events.sqlite`
+2. **Generation** — aggregate signals into proposals (fingerprints dedupe)
+3. **Scope** — project vs global per path/language
+4. **Review** — `/coach review` approves/rejects/edits
+5. **Apply** — approved rules → CLAUDE.md
+6. **Retro** — `/coach retro` maps manual work to skill gaps, opens PRs at source repos
 
 ## File Locations
 


### PR DESCRIPTION
## Summary

Adds a new \`PROCESS_VIOLATION\` signal type that detects Claude's own breaches of project workflow rules — orthogonal to \`USER_CORRECTION\` (user reacting) and \`COMMAND_FAILURE\` (tool reacting).

## Changes

### `scripts/detect_signals.py`

- New signal type \`PROCESS_VIOLATION\` (priority 90, between COMMAND_FAILURE and USER_CORRECTION)
- New pattern groups in default config:
  - \`unauthorized_squash\` — \`gh pr merge --squash\`, \`git merge --squash\`, interactive rebase with squash keyword
  - \`cache_path_edit\` — Write/Edit/MultiEdit targeting \`~/.claude/skills/\`, \`~/.claude/plugins/cache/\`, marketplaces, or \`.bare/\` paths
  - \`premature_success_claims\` — assistant text with \"verified/tested/all green/should work now\" etc.
- New method \`detect_process_violation(command, tool_name, file_path, assistant_text, has_preceding_tool_output)\` — the premature-claim check requires \`has_preceding_tool_output=False\` so benign post-test claims don't fire
- Wired into \`process_tool_result()\` so Bash squash and Write/Edit cache-path are caught at the PostToolUse hook
- stdin handler now forwards \`tool_name\` and \`tool_input.file_path\` through

### `references/signal_patterns.md`

- Documents the three violation kinds, regex patterns, detection hook points
- **False-positive notes**: squash is legitimate on squash-policy repos (aggregator filters via repo merge policy); cache-path patterns should only feed Write/Edit/MultiEdit events; success-claim patterns should only feed declarative assistant messages
- Updated priority weighting and evidence requirements tables

## Testing

Manual test: 8/8 cases (positives and negatives) classify correctly:

```
squash: unauthorized_squash
cache: cache_path_edit
claim: premature_success_claim
claim-with-output: None
benign: None
merge: None
bare: cache_path_edit
git-squash: unauthorized_squash
```

## Why

Three recurring process violations flagged by the recent insights report:
- Claude squashing commits despite the atomic-commit convention
- Claude editing installed caches, causing the next plugin update to wipe work
- Claude claiming \"tested/verified\" in assistant messages without running the test

## Test plan

- [ ] \`pytest\` (if any) still passes
- [ ] Detector test matrix re-run after merge
- [ ] Downstream aggregator handles the new signal type gracefully (just passes it through to candidates generation)