### PR TITLE
feat(aggregate): cluster PROCESS_VIOLATION signals by kind

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -1273,11 +1273,14 @@ class CandidateAggregator:
         """Extract a canonical base command for clustering (e.g. 'gh pr merge').
 
         Keeps up to the first 3 non-flag tokens; collapses casing and whitespace.
+        Returns 'unknown' for empty or whitespace-only input.
         """
-        if not command:
+        stripped = (command or "").strip()
+        if not stripped:
             return "unknown"
+        parts = stripped.split()
         tokens: List[str] = []
-        for tok in command.strip().split():
+        for tok in parts:
             if tok.startswith("-"):
                 break
             tokens.append(tok.lower())
@@ -1286,7 +1289,7 @@ class CandidateAggregator:
         # Special-case: keep 'git merge --squash' recognisable even though --squash
         # is a flag; the unauthorized_squash detector specifically pairs it with
         # 'git merge', so emit a stable label.
-        joined = " ".join(tokens) if tokens else command.strip().split()[0].lower()
+        joined = " ".join(tokens) if tokens else parts[0].lower()
         if joined == "git merge" and "--squash" in command:
             return "git merge --squash"
         return joined
@@ -1303,11 +1306,11 @@ class CandidateAggregator:
 
     @staticmethod
     def _repo_allows_squash() -> Optional[bool]:
-        """Best-effort check of `gh api repos/OWNER/REPO --jq .allow_squash_merge`.
+        """Best-effort check of `gh repo view --json squashMergeAllowed`.
 
         Returns True/False if the call succeeds, None if gh is unavailable,
-        the cwd isn't a repo, or the API call fails. Timeboxed to keep the
-        aggregator fast.
+        the cwd isn't a repo, or the API call fails. Timeboxed to 5 s to keep
+        the aggregator fast.
         """
         try:
             result = subprocess.run(
@@ -1336,11 +1339,20 @@ class CandidateAggregator:
             return None
 
     def _iter_violations(self, events: List[Dict]):
-        """Yield (event, content, violation) triples for every inner violation."""
+        """Yield (event, content, violation) triples for every inner violation.
+
+        Safe against sqlite/JSON edge cases: an event with an explicit
+        `content = NULL` (i.e. `event.get("content")` returns None rather than
+        the default "{}") would pass json.loads(None) → TypeError. The `or "{}"`
+        guards that case too.
+        """
         for event in events:
+            raw = event.get("content") or "{}"
             try:
-                content = json.loads(event.get("content", "{}"))
+                content = json.loads(raw)
             except Exception:
+                content = {}
+            if not isinstance(content, dict):
                 content = {}
             violations = content.get("violations", []) or []
             for v in violations:

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -1246,6 +1246,361 @@ class CandidateAggregator:
 
         return candidates
 
+    # --- PROCESS_VIOLATION clustering ---------------------------------------
+
+    # Map of cache-path regex -> (canonical path-prefix label, slug).
+    # The slug is an alphanumeric/underscore token that survives fingerprint
+    # normalization (which replaces raw paths with "<PATH>"), keeping
+    # fingerprints unique per prefix. Order matters: more specific first.
+    CACHE_PATH_PREFIXES = [
+        ("~/.claude/skills/", r"[/~]\.claude/skills/", "claude_skills"),
+        (
+            "~/.claude/plugins/cache/",
+            r"[/~]\.claude/plugins/cache/",
+            "claude_plugins_cache",
+        ),
+        (
+            "~/.claude/plugins/marketplaces/",
+            r"[/~]\.claude/plugins/marketplaces/",
+            "claude_plugins_marketplaces",
+        ),
+        ("/.bare/", r"/\.bare/", "git_bare_dir"),
+        ("/.bare", r"/\.bare$", "git_bare_root"),
+    ]
+
+    @staticmethod
+    def _base_command(command: str) -> str:
+        """Extract a canonical base command for clustering (e.g. 'gh pr merge').
+
+        Keeps up to the first 3 non-flag tokens; collapses casing and whitespace.
+        """
+        if not command:
+            return "unknown"
+        tokens: List[str] = []
+        for tok in command.strip().split():
+            if tok.startswith("-"):
+                break
+            tokens.append(tok.lower())
+            if len(tokens) == 3:
+                break
+        # Special-case: keep 'git merge --squash' recognisable even though --squash
+        # is a flag; the unauthorized_squash detector specifically pairs it with
+        # 'git merge', so emit a stable label.
+        joined = " ".join(tokens) if tokens else command.strip().split()[0].lower()
+        if joined == "git merge" and "--squash" in command:
+            return "git merge --squash"
+        return joined
+
+    @staticmethod
+    def _classify_cache_path(path: str) -> Tuple[str, str]:
+        """Map a file path to its (label, slug), or ('', '') if unknown."""
+        if not path:
+            return ("", "")
+        for label, pattern, slug in CandidateAggregator.CACHE_PATH_PREFIXES:
+            if re.search(pattern, path):
+                return (label, slug)
+        return ("", "")
+
+    @staticmethod
+    def _repo_allows_squash() -> Optional[bool]:
+        """Best-effort check of `gh api repos/OWNER/REPO --jq .allow_squash_merge`.
+
+        Returns True/False if the call succeeds, None if gh is unavailable,
+        the cwd isn't a repo, or the API call fails. Timeboxed to keep the
+        aggregator fast.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "repo",
+                    "view",
+                    "--json",
+                    "squashMergeAllowed",
+                    "--jq",
+                    ".squashMergeAllowed",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                return None
+            value = result.stdout.strip().lower()
+            if value == "true":
+                return True
+            if value == "false":
+                return False
+            return None
+        except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+            return None
+
+    def _iter_violations(self, events: List[Dict]):
+        """Yield (event, content, violation) triples for every inner violation."""
+        for event in events:
+            try:
+                content = json.loads(event.get("content", "{}"))
+            except Exception:
+                content = {}
+            violations = content.get("violations", []) or []
+            for v in violations:
+                if isinstance(v, dict):
+                    yield event, content, v
+
+    def _cluster_unauthorized_squash(
+        self, triples: List[Tuple[Dict, Dict, Dict]]
+    ) -> List[Dict]:
+        """Cluster unauthorized_squash violations by base command."""
+        if not triples:
+            return []
+
+        # Resolve repo policy once — shared across clusters for this run.
+        allow_squash = self._repo_allows_squash()
+
+        groups: Dict[str, List[Tuple[Dict, Dict, Dict]]] = defaultdict(list)
+        for event, content, v in triples:
+            base = self._base_command(v.get("command", ""))
+            groups[base].append((event, content, v))
+
+        candidates: List[Dict] = []
+        for base, members in groups.items():
+            sample_cmds = [
+                (m[2].get("command") or "")[:200]
+                for m in members
+                if m[2].get("command")
+            ]
+            repo_note = ""
+            if allow_squash is True:
+                repo_note = " (repo policy allows squash merges — verify whether atomic commits are still preferred)"
+            elif allow_squash is False:
+                repo_note = (
+                    " (repo policy disallows squash merges — this would fail anyway)"
+                )
+
+            action = (
+                f"prefer atomic commits when invoking `{base}`; only use --squash "
+                f"when the repo's policy is squash-only{repo_note}"
+            )
+            candidate = {
+                "id": str(uuid.uuid4())[:8],
+                "title": f"Avoid unauthorized squash via `{base}`",
+                "candidate_type": "antipattern",
+                "trigger": f"when running `{base}` with --squash",
+                "action": action,
+                "evidence": [
+                    {
+                        "event_id": m[0]["id"],
+                        "command": (m[2].get("command") or "")[:200],
+                        "pattern": m[2].get("pattern", ""),
+                    }
+                    for m in members[:5]
+                ],
+                "confidence": min(0.70 + 0.05 * len(members), 0.95),
+                "status": "pending",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "violation_kind": "unauthorized_squash",
+                "base_command": base,
+                "occurrence_count": len(members),
+                "sample_commands": sample_cmds[:5],
+                "repo_allow_squash_merge": allow_squash,
+            }
+            candidate["fingerprint"] = fingerprint_candidate(candidate)
+            candidates.append(candidate)
+        return candidates
+
+    def _cluster_cache_path_edit(
+        self, triples: List[Tuple[Dict, Dict, Dict]]
+    ) -> List[Dict]:
+        """Cluster cache_path_edit violations by path-prefix."""
+        if not triples:
+            return []
+
+        groups: Dict[Tuple[str, str], List[Tuple[Dict, Dict, Dict]]] = defaultdict(list)
+        for event, content, v in triples:
+            prefix, slug = self._classify_cache_path(v.get("file_path", ""))
+            if not prefix:
+                # Fallback bucket so we still produce a candidate rather than losing it.
+                prefix = "<unknown-cache-path>"
+                slug = "unknown_cache_path"
+            groups[(prefix, slug)].append((event, content, v))
+
+        candidates: List[Dict] = []
+        for (prefix, slug), members in groups.items():
+            distinct_files = {
+                m[2].get("file_path", "") for m in members if m[2].get("file_path")
+            }
+            tools_used = sorted(
+                {m[2].get("tool", "") for m in members if m[2].get("tool")}
+            )
+
+            # The slug is embedded in trigger/action so fingerprints stay unique
+            # per prefix even after normalization strips the raw path.
+            action = (
+                f"never edit `{prefix}` (cache_prefix_{slug}) — it is regenerated "
+                f"on plugin/skill update and manual edits will be clobbered. "
+                f"Make changes at the source repo instead."
+            )
+            candidate = {
+                "id": str(uuid.uuid4())[:8],
+                "title": f"Do not edit files under `{prefix}`",
+                "candidate_type": "rule",
+                "trigger": (
+                    f"when editing any file under `{prefix}` (cache_prefix_{slug})"
+                ),
+                "action": action,
+                "evidence": [
+                    {
+                        "event_id": m[0]["id"],
+                        "file_path": m[2].get("file_path", ""),
+                        "tool": m[2].get("tool", ""),
+                    }
+                    for m in members[:5]
+                ],
+                "confidence": min(0.75 + 0.05 * len(members), 0.95),
+                "status": "pending",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "violation_kind": "cache_path_edit",
+                "path_prefix": prefix,
+                "path_prefix_slug": slug,
+                "occurrence_count": len(members),
+                "distinct_file_count": len(distinct_files),
+                "tools_used": tools_used,
+            }
+            candidate["fingerprint"] = fingerprint_candidate(candidate)
+            candidates.append(candidate)
+        return candidates
+
+    def _cluster_premature_success_claim(
+        self, triples: List[Tuple[Dict, Dict, Dict]]
+    ) -> List[Dict]:
+        """Cluster premature_success_claim violations by session.
+
+        The current events schema has no explicit session_id, so we approximate
+        sessions using (repo_id, YYYY-MM-DD) from the event row — one candidate
+        per repo per day is a reasonable proxy for "per session".
+        """
+        if not triples:
+            return []
+
+        groups: Dict[Tuple[str, str], List[Tuple[Dict, Dict, Dict]]] = defaultdict(list)
+        for event, content, v in triples:
+            repo_id = event.get("repo_id") or "unknown-repo"
+            ts = event.get("timestamp") or ""
+            day = ts[:10] if ts else "unknown-day"
+            session_key = (repo_id, day)
+            groups[session_key].append((event, content, v))
+
+        candidates: List[Dict] = []
+        for (repo_id, day), members in groups.items():
+            # Collect snippets, redacting anything longer than 200 chars.
+            raw_snippets = [
+                m[2].get("snippet", "") for m in members if m[2].get("snippet")
+            ]
+            snippets: List[str] = []
+            for s in raw_snippets[:5]:
+                if len(s) > 200:
+                    snippets.append(s[:200] + "… [redacted]")
+                else:
+                    snippets.append(s)
+            patterns_seen = sorted(
+                {m[2].get("pattern", "") for m in members if m[2].get("pattern")}
+            )
+
+            action = (
+                "require command-output evidence (test runner, linter, build) "
+                "in the same turn before claiming something is 'verified', "
+                "'all green', or 'tested and working'"
+            )
+            candidate = {
+                "id": str(uuid.uuid4())[:8],
+                "title": "Require evidence before success claims",
+                "candidate_type": "checklist",
+                "trigger": (
+                    "before writing 'verified' / 'tests pass' / 'should work now' "
+                    "in assistant output"
+                ),
+                "action": action,
+                "evidence": [
+                    {
+                        "event_id": m[0]["id"],
+                        "snippet": (m[2].get("snippet") or "")[:200],
+                        "pattern": m[2].get("pattern", ""),
+                    }
+                    for m in members[:5]
+                ],
+                "confidence": min(0.70 + 0.05 * len(members), 0.95),
+                "status": "pending",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "violation_kind": "premature_success_claim",
+                "session_key": f"{repo_id}:{day}",
+                "repo_id": repo_id,
+                "session_day": day,
+                "occurrence_count": len(members),
+                "snippets": snippets,
+                "patterns": patterns_seen,
+            }
+            candidate["fingerprint"] = fingerprint_candidate(candidate)
+            candidates.append(candidate)
+        return candidates
+
+    def extract_candidate_from_process_violation(
+        self, events: List[Dict]
+    ) -> List[Dict]:
+        """Cluster PROCESS_VIOLATION events into per-kind actionable candidates.
+
+        Splits each event's inner `violations` list by `kind`, then delegates to
+        a kind-specific clustering helper. Any violation whose kind is unknown
+        (future-proofing / belt-and-braces) falls through to a generic
+        one-candidate-per-kind bucket so nothing is lost.
+        """
+        if not events:
+            return []
+
+        by_kind: Dict[str, List[Tuple[Dict, Dict, Dict]]] = defaultdict(list)
+        for event, content, violation in self._iter_violations(events):
+            kind = violation.get("kind", "unknown") or "unknown"
+            by_kind[kind].append((event, content, violation))
+
+        candidates: List[Dict] = []
+        candidates.extend(
+            self._cluster_unauthorized_squash(by_kind.pop("unauthorized_squash", []))
+        )
+        candidates.extend(
+            self._cluster_cache_path_edit(by_kind.pop("cache_path_edit", []))
+        )
+        candidates.extend(
+            self._cluster_premature_success_claim(
+                by_kind.pop("premature_success_claim", [])
+            )
+        )
+
+        # Fallback: any remaining (unknown future) kinds get a generic pass-through
+        # candidate per kind so they surface during review instead of being dropped.
+        for kind, members in by_kind.items():
+            action = (
+                f"review {len(members)} unclustered process-violation events of "
+                f"kind '{kind}' — no dedicated handler yet"
+            )
+            candidate = {
+                "id": str(uuid.uuid4())[:8],
+                "title": f"Unclustered process violation: {kind}",
+                "candidate_type": "rule",
+                "trigger": f"when process-violation kind '{kind}' fires",
+                "action": action,
+                "evidence": [
+                    {"event_id": m[0]["id"], "violation": m[2]} for m in members[:5]
+                ],
+                "confidence": 0.55,
+                "status": "pending",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "violation_kind": kind,
+                "occurrence_count": len(members),
+            }
+            candidate["fingerprint"] = fingerprint_candidate(candidate)
+            candidates.append(candidate)
+
+        return candidates
+
     def _extract_core_instruction(self, messages: List[str]) -> str:
         """Extract the core repeated instruction."""
         if not messages:
@@ -1315,6 +1670,14 @@ class CandidateAggregator:
             )
             candidates.extend(verification_candidates)
             processed_ids.extend([e["id"] for e in groups["VERIFICATION_QUESTION"]])
+
+        # Process PROCESS_VIOLATION (cluster by violation kind)
+        if "PROCESS_VIOLATION" in groups:
+            violation_candidates = self.extract_candidate_from_process_violation(
+                groups["PROCESS_VIOLATION"]
+            )
+            candidates.extend(violation_candidates)
+            processed_ids.extend([e["id"] for e in groups["PROCESS_VIOLATION"]])
 
         # Process TONE_ESCALATION (mark as processed, combine with other signals for context)
         if "TONE_ESCALATION" in groups:

--- a/scripts/tests/test_process_violation_clustering.py
+++ b/scripts/tests/test_process_violation_clustering.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Tests for PROCESS_VIOLATION clustering in the candidate aggregator.
+
+Builds three synthetic events per violation kind (nine violations total,
+three kinds) and asserts that the aggregator collapses each kind into the
+expected number of clustered candidates.
+
+The test avoids touching ~/.claude-coach/* by calling the clustering helpers
+directly on in-memory event rows — no DB required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Make scripts/ importable so test can be run from any cwd.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from aggregate import CandidateAggregator  # noqa: E402
+
+
+def _make_event(
+    event_id: str, violations, repo_id="repo-a", timestamp="2026-04-18T09:00:00Z"
+):
+    """Build a minimal event row matching the events table shape."""
+    return {
+        "id": event_id,
+        "timestamp": timestamp,
+        "event_type": "tool",
+        "signal_type": "PROCESS_VIOLATION",
+        "repo_id": repo_id,
+        "content": json.dumps(
+            {
+                "signal_type": "PROCESS_VIOLATION",
+                "violations": violations,
+                "confidence": 0.8,
+            }
+        ),
+        "context": "{}",
+        "processed": 0,
+    }
+
+
+class ProcessViolationClusteringTests(unittest.TestCase):
+    def setUp(self):
+        # Disable transcript analyzer so constructing the aggregator is cheap
+        # and doesn't touch ~/.claude.
+        self.aggregator = CandidateAggregator(analyze_transcript=False)
+
+    def test_unauthorized_squash_clusters_by_base_command(self):
+        """Three squash violations across two base commands -> two candidates."""
+        events = [
+            _make_event(
+                "ev-sq-1",
+                [
+                    {
+                        "kind": "unauthorized_squash",
+                        "pattern": r"\bgh\s+pr\s+merge\b[^\n]*--squash\b",
+                        "command": "gh pr merge 42 --squash --delete-branch",
+                    }
+                ],
+            ),
+            _make_event(
+                "ev-sq-2",
+                [
+                    {
+                        "kind": "unauthorized_squash",
+                        "pattern": r"\bgh\s+pr\s+merge\b[^\n]*--squash\b",
+                        "command": "gh pr merge --squash --auto",
+                    }
+                ],
+            ),
+            _make_event(
+                "ev-sq-3",
+                [
+                    {
+                        "kind": "unauthorized_squash",
+                        "pattern": r"\bgit\s+merge\s+--squash\b",
+                        "command": "git merge --squash feature-branch",
+                    }
+                ],
+            ),
+        ]
+
+        # Force repo-policy lookup to a known value so the test is deterministic
+        # regardless of the cwd gh happens to see.
+        with patch.object(
+            CandidateAggregator, "_repo_allows_squash", staticmethod(lambda: False)
+        ):
+            candidates = self.aggregator.extract_candidate_from_process_violation(
+                events
+            )
+
+        self.assertEqual(len(candidates), 2, candidates)
+        kinds = {c["violation_kind"] for c in candidates}
+        self.assertEqual(kinds, {"unauthorized_squash"})
+
+        by_base = {c["base_command"]: c for c in candidates}
+        self.assertIn("gh pr merge", by_base)
+        self.assertIn("git merge --squash", by_base)
+
+        gh_cand = by_base["gh pr merge"]
+        self.assertEqual(gh_cand["occurrence_count"], 2)
+        self.assertEqual(gh_cand["candidate_type"], "antipattern")
+        self.assertEqual(gh_cand["repo_allow_squash_merge"], False)
+        # Fingerprint must be stable & unique per base command.
+        self.assertNotEqual(
+            gh_cand["fingerprint"],
+            by_base["git merge --squash"]["fingerprint"],
+        )
+
+    def test_cache_path_edit_clusters_by_path_prefix(self):
+        """Three cache-path edits across two prefixes -> two candidates."""
+        events = [
+            _make_event(
+                "ev-cp-1",
+                [
+                    {
+                        "kind": "cache_path_edit",
+                        "pattern": r"[/~]\.claude/skills/",
+                        "tool": "Edit",
+                        "file_path": "/home/x/.claude/skills/coach/SKILL.md",
+                    }
+                ],
+            ),
+            _make_event(
+                "ev-cp-2",
+                [
+                    {
+                        "kind": "cache_path_edit",
+                        "pattern": r"[/~]\.claude/skills/",
+                        "tool": "Write",
+                        "file_path": "~/.claude/skills/coach/scripts/x.py",
+                    }
+                ],
+            ),
+            _make_event(
+                "ev-cp-3",
+                [
+                    {
+                        "kind": "cache_path_edit",
+                        "pattern": r"/\.bare/",
+                        "tool": "Edit",
+                        "file_path": "/home/cybot/projects/foo/.bare/HEAD",
+                    }
+                ],
+            ),
+        ]
+
+        candidates = self.aggregator.extract_candidate_from_process_violation(events)
+
+        self.assertEqual(len(candidates), 2, candidates)
+        by_prefix = {c["path_prefix"]: c for c in candidates}
+        self.assertIn("~/.claude/skills/", by_prefix)
+        self.assertIn("/.bare/", by_prefix)
+
+        skills = by_prefix["~/.claude/skills/"]
+        self.assertEqual(skills["occurrence_count"], 2)
+        self.assertEqual(skills["distinct_file_count"], 2)
+        self.assertEqual(skills["candidate_type"], "rule")
+        self.assertEqual(sorted(skills["tools_used"]), ["Edit", "Write"])
+
+        # Fingerprints differ across clusters.
+        self.assertNotEqual(skills["fingerprint"], by_prefix["/.bare/"]["fingerprint"])
+
+    def test_premature_success_claim_clusters_by_session(self):
+        """Three claim violations across two (repo, day) sessions -> two candidates."""
+        events = [
+            _make_event(
+                "ev-ps-1",
+                [
+                    {
+                        "kind": "premature_success_claim",
+                        "pattern": r"\bverified\b",
+                        "snippet": "I've verified the changes — all tests pass.",
+                    }
+                ],
+                repo_id="repo-a",
+                timestamp="2026-04-18T10:00:00Z",
+            ),
+            _make_event(
+                "ev-ps-2",
+                [
+                    {
+                        "kind": "premature_success_claim",
+                        "pattern": r"\bshould\s+work\s+now\b",
+                        "snippet": "It should work now. Try again.",
+                    }
+                ],
+                repo_id="repo-a",
+                timestamp="2026-04-18T14:30:00Z",
+            ),
+            _make_event(
+                "ev-ps-3",
+                [
+                    {
+                        "kind": "premature_success_claim",
+                        "pattern": r"\ball\s+green\b",
+                        # Intentionally long to exercise the redaction path.
+                        "snippet": "all green " + ("x" * 400),
+                    }
+                ],
+                repo_id="repo-b",
+                timestamp="2026-04-18T11:00:00Z",
+            ),
+        ]
+
+        candidates = self.aggregator.extract_candidate_from_process_violation(events)
+
+        self.assertEqual(len(candidates), 2, candidates)
+        by_session = {c["session_key"]: c for c in candidates}
+        self.assertIn("repo-a:2026-04-18", by_session)
+        self.assertIn("repo-b:2026-04-18", by_session)
+
+        a = by_session["repo-a:2026-04-18"]
+        self.assertEqual(a["occurrence_count"], 2)
+        self.assertEqual(a["candidate_type"], "checklist")
+        # Snippets for the two repo-a events are preserved (both <200 chars).
+        self.assertEqual(len(a["snippets"]), 2)
+
+        b = by_session["repo-b:2026-04-18"]
+        self.assertEqual(b["occurrence_count"], 1)
+        # Long snippet should be truncated with redaction marker.
+        self.assertTrue(any("[redacted]" in s for s in b["snippets"]), b["snippets"])
+
+    def test_unknown_kind_falls_through(self):
+        """Unknown violation kinds get a generic pass-through candidate."""
+        events = [
+            _make_event(
+                "ev-unk-1",
+                [
+                    {
+                        "kind": "future_kind_xyz",
+                        "pattern": r"\bfoo\b",
+                        "command": "foo bar",
+                    }
+                ],
+            ),
+        ]
+        candidates = self.aggregator.extract_candidate_from_process_violation(events)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["violation_kind"], "future_kind_xyz")
+        self.assertEqual(candidates[0]["candidate_type"], "rule")
+
+    def test_fingerprint_stable_across_runs(self):
+        """Running clustering twice on the same input yields the same fingerprints."""
+        events = [
+            _make_event(
+                "ev-stable",
+                [
+                    {
+                        "kind": "cache_path_edit",
+                        "pattern": r"[/~]\.claude/skills/",
+                        "tool": "Edit",
+                        "file_path": "~/.claude/skills/coach/SKILL.md",
+                    }
+                ],
+            ),
+        ]
+        first = self.aggregator.extract_candidate_from_process_violation(events)
+        second = self.aggregator.extract_candidate_from_process_violation(events)
+        self.assertEqual(first[0]["fingerprint"], second[0]["fingerprint"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_process_violation_clustering.py
+++ b/scripts/tests/test_process_violation_clustering.py
@@ -5,8 +5,11 @@ Builds three synthetic events per violation kind (nine violations total,
 three kinds) and asserts that the aggregator collapses each kind into the
 expected number of clustered candidates.
 
-The test avoids touching ~/.claude-coach/* by calling the clustering helpers
-directly on in-memory event rows — no DB required.
+The tests call the clustering helpers directly on in-memory event rows —
+no sqlite DB access is performed. Note that `CandidateAggregator.__init__`
+still reads `~/.claude-coach/config.json` if it exists (via `_load_config`);
+the tests tolerate either an existing config file or an absent one, so
+running them on a developer machine with a live coach install is safe.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds a dedicated `PROCESS_VIOLATION` handler to `scripts/aggregate.py` that clusters events by their inner `kind`, replacing the current pass-through which produced noisy generic candidates.

### Per-kind clustering

- **`unauthorized_squash`** - cluster by base command (`gh pr merge`, `git merge --squash`, …). Candidate type: `antipattern`. Proposes atomic commits and includes a best-effort `gh repo view --json squashMergeAllowed` lookup so the repo policy surfaces in the proposal text (without blocking the aggregator if `gh` is absent or times out).
- **`cache_path_edit`** - cluster by path-prefix (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `/.bare/`, …). Candidate type: `rule`. Includes aggregated counts of distinct target files and the set of tools (Write/Edit/MultiEdit) used. Each prefix carries a stable alphanumeric slug (e.g. `cache_prefix_claude_skills`) so fingerprints stay unique per prefix even after the normalizer collapses raw paths to `<PATH>`.
- **`premature_success_claim`** - cluster by `(repo_id, YYYY-MM-DD)` from the event row. The events schema has no explicit `session_id`, so per-repo per-day is the closest proxy to "per session". Candidate type: `checklist`. Snippets longer than 200 chars are truncated with a redaction marker.
- **Unknown `kind`** - falls through to a generic pass-through candidate (belt-and-braces: nothing is silently lost).

### Candidate metadata

Each clustered candidate carries a `violation_kind` marker plus cluster-specific fields (`base_command`, `path_prefix`, `path_prefix_slug`, `session_key`, `occurrence_count`, …) to make downstream `/coach:review` and `/coach:approve` easier.

### Test plan

- [x] `ruff format scripts/`
- [x] `ruff check scripts/`
- [x] `python scripts/tests/test_process_violation_clustering.py` - 5 tests, all passing:
  - `test_unauthorized_squash_clusters_by_base_command`: 3 synthetic events across 2 base commands -> 2 candidates
  - `test_cache_path_edit_clusters_by_path_prefix`: 3 synthetic events across 2 path prefixes -> 2 candidates (plus fingerprint-uniqueness assertion)
  - `test_premature_success_claim_clusters_by_session`: 3 synthetic events across 2 `(repo, day)` sessions -> 2 candidates (plus redaction-path check)
  - `test_unknown_kind_falls_through`: unknown future kind -> 1 generic candidate
  - `test_fingerprint_stable_across_runs`: identical input -> identical fingerprints

### Design notes

- Looked for an existing clustering helper to reuse; the nearest precedent is the per-tool grouping in `extract_candidate_from_version_issue`, but it's too specific (keyed on `content['tool']`). I followed its shape for style consistency but broke clustering out into one `_cluster_<kind>` helper per violation kind — simpler to extend when new kinds land.
- Real bug surfaced during test authoring: the `fingerprint` normalizer replaces `/…` paths with `<PATH>`, so `~/.claude/skills/` and `/.bare/` originally collapsed to the same fingerprint. Fixed by embedding a stable slug token (alphanumeric + underscore, survives the normalizer) in both trigger and action for cache-path candidates.
- `_repo_allows_squash()` is timeboxed at 5s and swallows all exceptions → `None`. The proposal text adapts to `True`/`False`/`None` so the aggregator stays robust when run outside a GitHub repo or when `gh` is unauthenticated.