### PR TITLE
chore(release): v2.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coach",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Self-improving learning system that detects friction signals (corrections, repetitions, tool failures), extracts improvement candidates, and proposes rule/skill updates with explicit approval workflow.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3 (for signal detection, aggregation, and analysis scripts)."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.5.0"
+  version: "2.5.1"
   repository: https://github.com/netresearch/claude-coach-plugin
 allowed-tools: Bash(python3:*) Bash(python:*) Bash(sqlite3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release **v2.5.1** (patch bump, conventional commits since v2.5.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 2.5.1.

Changes since v2.5.0:
- ci(release): grant SLSA provenance permissions
- 
- Required by netresearch/skill-repo-skill/.github/workflows/release.yml,
- which generates SLSA build-provenance attestations for release archives
- via actions/attest-build-provenance. The reusable workflow's attest job
- needs id-token: write (OIDC for sigstore) and attestations: write
- (GitHub native attestation API) on the calling job.
- 
- Also drops pull-requests: write — the reusable workflow doesn't touch
- the pulls API; it was over-privileging.
- ci(release): add trailing newline (yamllint fix)
- 
- ci(release): grant SLSA provenance permissions

After merge: a signed tag `v2.5.1` on `main` triggers the release workflow.