### PR TITLE
fix(scope): write project-scoped rules to AGENTS.md, not .claude/CLAUDE.md

### DIFF
--- a/commands/approve.md
+++ b/commands/approve.md
@@ -15,7 +15,7 @@ Approve a pending learning candidate and apply it to CLAUDE.md.
 1. Read `~/.claude-coach/candidates.json` and find the candidate by ID
 
 2. Determine target location based on candidate scope:
-   - Project scope → `<repo>/.claude/CLAUDE.md`
+   - Project scope → `<repo>/AGENTS.md`
    - Global scope → `~/.claude/CLAUDE.md`
 
 3. Apply the proposal using the apply script:

--- a/commands/promote.md
+++ b/commands/promote.md
@@ -16,11 +16,11 @@ Move an approved project-scope rule to global scope.
 
 2. Verify it's currently project-scoped and approved
 
-3. Read the rule from `<repo>/.claude/CLAUDE.md`
+3. Read the rule from `<repo>/AGENTS.md`
 
 4. Add the rule to `~/.claude/CLAUDE.md` under appropriate section
 
-5. Optionally remove from project CLAUDE.md (ask user)
+5. Optionally remove from project AGENTS.md (ask user)
 
 6. Update candidate scope to "global" in candidates.json
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -71,7 +71,7 @@ candidate = {
 ### 4. Proposal Application (apply.py)
 
 Target locations:
-- Project: `<repo>/.claude/CLAUDE.md`
+- Project: `<repo>/AGENTS.md`
 - Global: `~/.claude/CLAUDE.md`
 
 ## Cross-Repo Learning

--- a/scripts/propose.py
+++ b/scripts/propose.py
@@ -29,27 +29,29 @@ class ProposalGenerator:
         candidate_type = candidate.get("candidate_type", "rule")
 
         if scope == "global":
+            # Global preferences go in the always-loaded global rules file.
             base = Path.home() / ".claude"
+            rules_file = base / "CLAUDE.md"
         else:
+            # Project rules live in the repo's AGENTS.md — the single project
+            # rule store — not <repo>/.claude/CLAUDE.md.
             base = Path.cwd() / ".claude"
+            rules_file = Path.cwd() / "AGENTS.md"
 
-        # Ensure base exists
-        base.mkdir(parents=True, exist_ok=True)
-
-        if candidate_type == "rule":
-            return base / "CLAUDE.md"
+        if candidate_type in ("rule", "antipattern"):
+            return rules_file
         elif candidate_type == "checklist":
+            base.mkdir(parents=True, exist_ok=True)
             (base / "checklists").mkdir(exist_ok=True)
             safe_title = self._safe_filename(candidate.get("title", "checklist"))
             return base / "checklists" / f"{safe_title}.md"
         elif candidate_type == "snippet":
+            base.mkdir(parents=True, exist_ok=True)
             (base / "snippets").mkdir(exist_ok=True)
             safe_title = self._safe_filename(candidate.get("title", "snippet"))
             return base / "snippets" / f"{safe_title}.md"
-        elif candidate_type == "antipattern":
-            return base / "CLAUDE.md"  # Anti-patterns go in main rules
         else:
-            return base / "CLAUDE.md"
+            return rules_file
 
     def _safe_filename(self, title: str) -> str:
         """Convert title to safe filename."""
@@ -122,13 +124,17 @@ class ProposalGenerator:
         else:
             old_content = ""
 
-        # For CLAUDE.md, append to existing content
-        if target_file.name == "CLAUDE.md":
-            # Find appropriate section or append
+        # For rules files (CLAUDE.md / AGENTS.md), append to existing content.
+        if target_file.name in ("CLAUDE.md", "AGENTS.md"):
             if old_content:
                 combined = old_content.rstrip() + "\n\n" + new_content.strip() + "\n"
             else:
-                combined = f"# Claude Code Instructions\n\n{new_content.strip()}\n"
+                header = (
+                    "# AGENTS.md"
+                    if target_file.name == "AGENTS.md"
+                    else "# Claude Code Instructions"
+                )
+                combined = f"{header}\n\n{new_content.strip()}\n"
         else:
             # For standalone files, use new content
             combined = new_content.strip() + "\n"

--- a/scripts/propose.py
+++ b/scripts/propose.py
@@ -12,7 +12,7 @@ from datetime import datetime, UTC
 from typing import Dict, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent))
-from scope_analyzer import ScopeAnalyzer
+from scope_analyzer import ScopeAnalyzer, repo_root
 
 COACH_DIR = Path.home() / ".claude-coach"
 CANDIDATES_FILE = COACH_DIR / "candidates.json"
@@ -34,9 +34,11 @@ class ProposalGenerator:
             rules_file = base / "CLAUDE.md"
         else:
             # Project rules live in the repo's AGENTS.md — the single project
-            # rule store — not <repo>/.claude/CLAUDE.md.
-            base = Path.cwd() / ".claude"
-            rules_file = Path.cwd() / "AGENTS.md"
+            # rule store at the repo root — not <repo>/.claude/CLAUDE.md. Resolve
+            # the repo root so this works when invoked from a subdirectory.
+            root = repo_root()
+            base = root / ".claude"
+            rules_file = root / "AGENTS.md"
 
         if candidate_type in ("rule", "antipattern"):
             return rules_file

--- a/scripts/scope_analyzer.py
+++ b/scripts/scope_analyzer.py
@@ -118,10 +118,10 @@ class ScopeAnalyzer:
             if fp.similarity(candidate_text, content) > 0.4:
                 result["exists_global"] = True
 
-        # Check project rules
-        project_claude_md = Path.cwd() / ".claude" / "CLAUDE.md"
-        if project_claude_md.exists():
-            content = project_claude_md.read_text()
+        # Check project rules (AGENTS.md is the project rule store)
+        project_rules_md = Path.cwd() / "AGENTS.md"
+        if project_rules_md.exists():
+            content = project_rules_md.read_text()
             candidate_text = (
                 f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
             )

--- a/scripts/scope_analyzer.py
+++ b/scripts/scope_analyzer.py
@@ -8,12 +8,40 @@ import sys
 import re
 import json
 import sqlite3
+import subprocess
 from pathlib import Path
 from typing import Dict, Tuple
 
 COACH_DIR = Path.home() / ".claude-coach"
 LEDGER_DB = COACH_DIR / "ledger.sqlite"
 CONFIG_FILE = COACH_DIR / "config.json"
+
+
+def repo_root() -> Path:
+    """Resolve the repository root for project-scoped files (AGENTS.md, .claude).
+
+    Project rules live in a single store at the repo root, so resolve it rather
+    than assuming the command runs from there. Prefer ``git rev-parse``; fall
+    back to walking up for a ``.git`` or ``AGENTS.md`` marker, then to cwd.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    start = Path.cwd().resolve()
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists() or (parent / "AGENTS.md").exists():
+            return parent
+    return start
+
 
 # Indicator patterns for scope detection
 PROJECT_INDICATORS = [
@@ -110,7 +138,7 @@ class ScopeAnalyzer:
         # Check global rules
         global_claude_md = Path.home() / ".claude" / "CLAUDE.md"
         if global_claude_md.exists():
-            content = global_claude_md.read_text()
+            content = global_claude_md.read_text(encoding="utf-8")
             # Simple similarity check
             candidate_text = (
                 f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
@@ -118,10 +146,10 @@ class ScopeAnalyzer:
             if fp.similarity(candidate_text, content) > 0.4:
                 result["exists_global"] = True
 
-        # Check project rules (AGENTS.md is the project rule store)
-        project_rules_md = Path.cwd() / "AGENTS.md"
+        # Check project rules (AGENTS.md is the project rule store at repo root)
+        project_rules_md = repo_root() / "AGENTS.md"
         if project_rules_md.exists():
-            content = project_rules_md.read_text()
+            content = project_rules_md.read_text(encoding="utf-8")
             candidate_text = (
                 f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
             )

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -45,7 +45,7 @@ Activate when: user corrections ("no", "stop", "don't"), repeated instructions, 
 2. **Generation** — aggregate signals into proposals (fingerprints dedupe)
 3. **Scope** — project vs global per path/language
 4. **Review** — `/coach review` approves/rejects/edits
-5. **Apply** — approved rules → CLAUDE.md
+5. **Apply** — approved rules → `~/.claude/CLAUDE.md` (global) or repo `AGENTS.md` (project)
 6. **Retro** — `/coach retro` maps manual work to skill gaps, opens PRs at source repos
 
 ## File Locations
@@ -56,8 +56,10 @@ Activate when: user corrections ("no", "stop", "don't"), repeated instructions, 
 ├── candidates.json    # Pending proposals
 └── ledger.sqlite      # Cross-repo fingerprints
 
+~/.claude/CLAUDE.md     # Global rules destination
+<repo>/AGENTS.md        # Project rules destination
+
 ~/.claude/ or <repo>/.claude/
-├── CLAUDE.md          # Rules destination
 ├── checklists/        # Workflow checklists
 └── snippets/          # Reusable commands
 ```


### PR DESCRIPTION
## Summary

Project-scoped coach rules were applied to `<repo>/.claude/CLAUDE.md`. Per the user's policy, project conventions belong in the repo's `AGENTS.md` — the single project rule store — not a project-local CLAUDE.md. Global rules continue to go in `~/.claude/CLAUDE.md`.

## Came from

`/retro audit` (meta-retro), 2026-06-03 — reviewing where agent-learned knowledge is stored. Policy: knowledge lives only in global user rules (`~/.claude/CLAUDE.md`), a project's `AGENTS.md`, or a skill.

## Change

- `propose.py` `get_target_file`: project-scope `rule`/`antipattern` → `<repo>/AGENTS.md`; the append path treats `AGENTS.md` like `CLAUDE.md` (uses an `# AGENTS.md` header when creating the file). `checklist`/`snippet` artifacts are unchanged (still under `.claude/`).
- `scope_analyzer.py`: existing-project-rule detection reads `<repo>/AGENTS.md`.
- Docs: `approve.md`, `promote.md`, `architecture.md`, `skills/coach/SKILL.md`.

## Test plan

- [x] `ruff format` + `ruff check` clean on changed scripts
- [x] Python syntax validated
- [ ] (manual) `/coach approve` a project-scoped candidate lands in `<repo>/AGENTS.md`
