### PR TITLE
chore(release): v2.5.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coach",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Self-improving learning system that detects friction signals (corrections, repetitions, tool failures), extracts improvement candidates, and proposes rule/skill updates with explicit approval workflow.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3 (for signal detection, aggregation, and analysis scripts)."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.5.1"
+  version: "2.5.2"
   repository: https://github.com/netresearch/claude-coach-plugin
 allowed-tools: Bash(python3:*) Bash(python:*) Bash(sqlite3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release v2.5.2 (patch).

Changes since v2.5.1 (PR #27):
- fix(scope): write project-scoped rules to AGENTS.md, not .claude/CLAUDE.md
- fix(scope): resolve repo root for project AGENTS.md, not cwd

Version bump only: .claude-plugin/plugin.json and skills/coach/SKILL.md.
