### PR TITLE
chore(release): v2.5.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coach",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Self-improving learning system that detects friction signals (corrections, repetitions, tool failures), extracts improvement candidates, and proposes rule/skill updates with explicit approval workflow.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3 (for signal detection, aggregation, and analysis scripts)."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.5.2"
+  version: "2.5.3"
   repository: https://github.com/netresearch/claude-coach-plugin
 allowed-tools: Bash(python3:*) Bash(python:*) Bash(sqlite3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release v2.5.3 (bump from v2.5.2): plugin.json + 1 SKILL.md version(s).