### PR TITLE
docs(templates): add Verification field to rule and antipattern templates

### DIFF
--- a/assets/templates/antipattern.md
+++ b/assets/templates/antipattern.md
@@ -4,6 +4,8 @@
 
 **Instead**: {{ACTION}}
 
+**Verification**: {{VERIFICATION}}
+
 {{#if RATIONALE}}
 **Rationale**: {{RATIONALE}}
 {{/if}}

--- a/assets/templates/rule.md
+++ b/assets/templates/rule.md
@@ -4,6 +4,8 @@
 
 **Action**: {{ACTION}}
 
+**Verification**: {{VERIFICATION}}
+
 {{#if EVIDENCE}}
 **Evidence**:
 {{#each EVIDENCE}}


### PR DESCRIPTION
## Summary

Adds a mandatory Verification field to the `rule.md` and `antipattern.md` candidate templates, aligning both with the canonical failure-pattern schema.

## Change

- `assets/templates/rule.md`: adds `**Verification**: {{VERIFICATION}}` after `Action`, alongside the existing `Trigger`/`Action` fields.
- `assets/templates/antipattern.md`: adds `**Verification**: {{VERIFICATION}}` after `Instead`, alongside the existing `Never`/`Instead` fields.

Verification names an eval id or checkpoint id, per the schema defined in `skill-repo-skill`'s `references/materialization-contract.md`. Format only — no changes to the candidate aggregation pipeline (`scripts/aggregate.py`, `references/schema.md`).

Part of the same format-propagation change as:
- netresearch/skill-repo-skill#158 (schema definition, Closes netresearch/skill-repo-skill#149)
- netresearch/retro-skill#30

## Test plan

- [x] `npx markdownlint-cli2 assets/templates/rule.md assets/templates/antipattern.md` — 0 errors

Part of https://github.com/netresearch/skill-repo-skill/issues/149