### PR TITLE
chore: release v2.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coach",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "Self-improving learning system that detects friction signals (corrections, repetitions, tool failures), extracts improvement candidates, and proposes rule/skill updates with explicit approval workflow.",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,13 +7,6 @@
     "url": "https://www.netresearch.de"
   },
   "repository": "https://github.com/netresearch/claude-coach-plugin",
-  "keywords": [
-    "learning",
-    "self-improvement",
-    "friction-detection",
-    "rules",
-    "meta"
-  ],
   "license": "(MIT AND CC-BY-SA-4.0)",
   "skills": [
     "./skills/coach"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,15 @@
 name: Security
 
-# Aggregated security scans for skill repos: secret scanning (gitleaks),
-# dependency review on PRs, and a composer audit (every skill repo ships a
-# composer.json for split-licensing / Packagist distribution).
+# Aggregated security scans for skill repos:
+#   gitleaks         — secret scanning. The job and the reusable keep the
+#                      historical `gitleaks` name; the scan itself runs
+#                      betterleaks, which is OSS and needs no license.
+#   zizmor           — static analysis of this repo's own workflows.
+#   dependency-review — on pull requests only.
+#   composer-audit   — `composer audit` AND an Opengrep SAST scan; the called
+#                      reusable runs both unless skip-opengrep is set. Every
+#                      skill repo ships a composer.json for split-licensing /
+#                      Packagist distribution.
 #
 # Top-level `permissions: {}` denies everything by default; each reusable
 # caller job re-declares the exact union its reusable's jobs require, so the
@@ -24,8 +31,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
 
   dependency-review:
     if: github.event_name == 'pull_request'

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "coach",
+  "version": "2.6.0",
+  "description": "Self-improving learning system that detects friction signals (corrections, repetitions, tool failures), extracts improvement candidates, and proposes rule/skill updates with explicit approval workflow.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  },
+  "repository": "https://github.com/netresearch/claude-coach-plugin"
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 120
+
+[lint]
+select = ["E", "F", "W"]
+ignore = ["E402", "E501"]

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python3 (for signal detection, aggregation, and analysis scripts)."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.5.3"
+  version: "2.6.0"
   repository: https://github.com/netresearch/claude-coach-plugin
 allowed-tools: Bash(python3:*) Bash(python:*) Bash(sqlite3:*) Read Write Glob Grep
 ---

--- a/skills/coach/references/architecture.md
+++ b/skills/coach/references/architecture.md
@@ -23,11 +23,7 @@ signal = {
     "content": "I said don't edit generated files",
     "timestamp": "2024-01-15T10:30:00Z",
     "context": {"file": "generated/api.ts", "action": "edit"},
-    "preceding_context": {
-        "recent_tool_calls": [...],
-        "recent_messages": [...],
-        "recent_actions": [...]
-    }
+    "preceding_context": {"recent_tool_calls": [...], "recent_messages": [...], "recent_actions": [...]},
 }
 # Stored in ~/.claude-coach/events.sqlite
 ```
@@ -46,7 +42,7 @@ candidate = {
     "action": "regenerate from source instead; patch source if needed",
     "evidence": [{"event_id": "...", "quote": "don't edit generated"}],
     "confidence": 0.85,
-    "status": "pending"
+    "status": "pending",
 }
 ```
 

--- a/skills/coach/references/scope_heuristics.md
+++ b/skills/coach/references/scope_heuristics.md
@@ -62,10 +62,8 @@ Rules for determining whether a learning candidate belongs at project or global 
 
 ```python
 def calculate_scope(candidate):
-    project_score = sum(weight for pattern, weight in PROJECT_INDICATORS
-                        if pattern in candidate_text)
-    global_score = sum(weight for pattern, weight in GLOBAL_INDICATORS
-                       if pattern in candidate_text)
+    project_score = sum(weight for pattern, weight in PROJECT_INDICATORS if pattern in candidate_text)
+    global_score = sum(weight for pattern, weight in GLOBAL_INDICATORS if pattern in candidate_text)
 
     # Decision thresholds
     if global_score > project_score * 1.5:

--- a/skills/coach/scripts/aggregate.py
+++ b/skills/coach/scripts/aggregate.py
@@ -34,9 +34,7 @@ COACH_DIR = Path.home() / ".claude-coach"
 EVENTS_DB = COACH_DIR / "events.sqlite"
 LEDGER_DB = COACH_DIR / "ledger.sqlite"
 CANDIDATES_FILE = COACH_DIR / "candidates.json"
-RAW_ANALYSIS_FILE = (
-    COACH_DIR / "raw_analysis.json"
-)  # For Claude Code to process at review time
+RAW_ANALYSIS_FILE = COACH_DIR / "raw_analysis.json"  # For Claude Code to process at review time
 CONFIG_FILE = COACH_DIR / "config.json"
 CONTEXT_FILE = COACH_DIR / "recent_context.json"
 
@@ -67,9 +65,7 @@ class TranscriptAnalyzer:
     ]
 
     def __init__(self):
-        self.correction_patterns = [
-            re.compile(p, re.IGNORECASE) for p in self.CORRECTION_PATTERNS
-        ]
+        self.correction_patterns = [re.compile(p, re.IGNORECASE) for p in self.CORRECTION_PATTERNS]
 
     def find_recent_transcript(self) -> Optional[Path]:
         """Find the most recent session transcript."""
@@ -122,17 +118,13 @@ class TranscriptAnalyzer:
                             messages.append(
                                 {
                                     "role": "user",
-                                    "content": entry.get("message", {}).get(
-                                        "content", ""
-                                    ),
+                                    "content": entry.get("message", {}).get("content", ""),
                                 }
                             )
                         elif entry_type == "assistant":
                             # Assistant response
                             msg = entry.get("message", {})
-                            messages.append(
-                                {"role": "assistant", "content": msg.get("content", [])}
-                            )
+                            messages.append({"role": "assistant", "content": msg.get("content", [])})
                         elif entry_type == "tool_result":
                             # Tool result - store for context
                             messages.append({"role": "tool_result", "content": entry})
@@ -142,9 +134,7 @@ class TranscriptAnalyzer:
         except Exception:
             return []
 
-    def extract_messages(
-        self, transcript: List[Dict]
-    ) -> Tuple[List[str], List[str], List[Dict]]:
+    def extract_messages(self, transcript: List[Dict]) -> Tuple[List[str], List[str], List[Dict]]:
         """Extract user messages, assistant messages, and tool calls with results from transcript."""
         user_messages = []
         assistant_messages = []
@@ -163,11 +153,7 @@ class TranscriptAnalyzer:
                         result_content = item.get("content", "")
                         # Extract text from content if it's a list
                         if isinstance(result_content, list):
-                            texts = [
-                                c.get("text", "")
-                                for c in result_content
-                                if c.get("type") == "text"
-                            ]
+                            texts = [c.get("text", "") for c in result_content if c.get("type") == "text"]
                             result_content = "\n".join(texts)
                         tool_results[tool_use_id] = {
                             "content": result_content,
@@ -202,9 +188,7 @@ class TranscriptAnalyzer:
                                 item["result"] = result.get("content", "")
                                 item["is_error"] = result.get("is_error", False)
                                 # Detect failure from result content
-                                result_text = (
-                                    item["result"].lower() if item["result"] else ""
-                                )
+                                result_text = item["result"].lower() if item["result"] else ""
                                 item["is_failure"] = (
                                     item["is_error"]
                                     or "error:" in result_text
@@ -315,9 +299,7 @@ class TranscriptAnalyzer:
     def detect_repeated_failures(self, tool_calls: List[Dict]) -> List[Dict]:
         """Detect repeated concerning tool calls in transcript with variation analysis."""
         # Track command sequences with more detail - now properly tracking failures vs successes
-        command_sequences = defaultdict(
-            lambda: {"attempts": [], "failures": [], "successes": []}
-        )
+        command_sequences = defaultdict(lambda: {"attempts": [], "failures": [], "successes": []})
 
         for call in tool_calls:
             tool_name = call.get("name", "")
@@ -331,9 +313,7 @@ class TranscriptAnalyzer:
                 base = " ".join(parts).lower()
 
                 # Skip benign commands that are expected to run multiple times
-                is_benign = any(
-                    benign in base for benign in self.BENIGN_REPEATED_COMMANDS
-                )
+                is_benign = any(benign in base for benign in self.BENIGN_REPEATED_COMMANDS)
                 if is_benign:
                     continue
 
@@ -342,9 +322,7 @@ class TranscriptAnalyzer:
                     "command": command,
                     "tool": tool_name,
                     "flags": [p for p in command.split() if p.startswith("-")],
-                    "args": [p for p in command.split() if not p.startswith("-")][
-                        2:
-                    ],  # Skip base cmd
+                    "args": [p for p in command.split() if not p.startswith("-")][2:],  # Skip base cmd
                     "result": call.get("result", ""),
                     "is_failure": call.get("is_failure", False),
                 }
@@ -365,9 +343,7 @@ class TranscriptAnalyzer:
             # Only flag if there were actual failures (2+ failures)
             if len(failures) >= 2:
                 # Prioritize known concerning commands
-                is_concerning = any(
-                    concern in base for concern in self.CONCERNING_COMMANDS
-                )
+                is_concerning = any(concern in base for concern in self.CONCERNING_COMMANDS)
                 if is_concerning or len(failures) >= 3:
                     # Detect if flags/args changed between attempts
                     variation_analysis = self._analyze_attempt_variations(attempts)
@@ -389,18 +365,12 @@ class TranscriptAnalyzer:
                             "variation_analysis": variation_analysis,
                             "resolution_found": resolution_found,
                             "resolution_command": resolution_command,
-                            "error_samples": [
-                                f.get("result", "")[:200]
-                                for f in failures[:3]
-                                if f.get("result")
-                            ],
+                            "error_samples": [f.get("result", "")[:200] for f in failures[:3] if f.get("result")],
                         }
                     )
 
         # Sort by concern level and occurrence count
-        repeated.sort(
-            key=lambda x: (not x.get("is_concerning", False), -x["occurrences"])
-        )
+        repeated.sort(key=lambda x: (not x.get("is_concerning", False), -x["occurrences"]))
         return repeated
 
     def _analyze_attempt_variations(self, attempts: List[Dict]) -> Dict:
@@ -415,15 +385,11 @@ class TranscriptAnalyzer:
             added = all_flags[i] - all_flags[i - 1]
             removed = all_flags[i - 1] - all_flags[i]
             if added or removed:
-                flag_changes.append(
-                    {"index": i, "added": list(added), "removed": list(removed)}
-                )
+                flag_changes.append({"index": i, "added": list(added), "removed": list(removed)})
 
         # Track argument changes
         all_args = [a.get("args", []) for a in attempts]
-        arg_changes = sum(
-            1 for i in range(1, len(all_args)) if all_args[i] != all_args[i - 1]
-        )
+        arg_changes = sum(1 for i in range(1, len(all_args)) if all_args[i] != all_args[i - 1])
 
         # Determine variation type
         if flag_changes:
@@ -443,9 +409,7 @@ class TranscriptAnalyzer:
                 "details": f"Same command retried {len(attempts)} times (possible transient failure)",
             }
 
-    def detect_implicit_corrections(
-        self, user_messages: List[str], assistant_messages: List[str]
-    ) -> List[Dict]:
+    def detect_implicit_corrections(self, user_messages: List[str], assistant_messages: List[str]) -> List[Dict]:
         """Detect implicit corrections - user doing what Claude should have done."""
         implicit = []
 
@@ -458,14 +422,9 @@ class TranscriptAnalyzer:
             msg_lower = msg.lower()
 
             # User providing code/commands that Claude should have generated
-            if any(
-                pattern in msg_lower
-                for pattern in ["```", "like this:", "try this:", "use this:"]
-            ):
+            if any(pattern in msg_lower for pattern in ["```", "like this:", "try this:", "use this:"]):
                 if i > 0:
-                    implicit.append(
-                        {"message": msg[:200], "type": "provided_solution", "index": i}
-                    )
+                    implicit.append({"message": msg[:200], "type": "provided_solution", "index": i})
 
             # User asking same thing differently
             if i >= 2:
@@ -475,9 +434,7 @@ class TranscriptAnalyzer:
                 for prev in prev_messages:
                     prev_words = set(prev.split())
                     if len(prev_words) > 5 and len(current_words) > 5:
-                        overlap = len(current_words & prev_words) / min(
-                            len(current_words), len(prev_words)
-                        )
+                        overlap = len(current_words & prev_words) / min(len(current_words), len(prev_words))
                         if overlap > 0.5:
                             implicit.append(
                                 {
@@ -526,15 +483,11 @@ class TranscriptAnalyzer:
                 "correction_count": len(corrections),
                 "failure_count": len(failures),
                 "implicit_count": len(implicit),
-                "high_intensity_corrections": [
-                    c for c in corrections if c.get("intensity", 0) >= 3
-                ],
+                "high_intensity_corrections": [c for c in corrections if c.get("intensity", 0) >= 3],
             },
         }
 
-    def _analyze_command_variations(
-        self, commands: List[Dict], base_cmd: str, occurrences: int
-    ) -> str:
+    def _analyze_command_variations(self, commands: List[Dict], base_cmd: str, occurrences: int) -> str:
         """Analyze command variations to extract specific patterns."""
         if not commands:
             return f"investigate why {base_cmd} fails repeatedly ({occurrences}x)"
@@ -614,11 +567,7 @@ class TranscriptAnalyzer:
                     # Feed failed commands to root cause analyzer with actual error messages
                     error_samples = failure.get("error_samples", [])
                     for i, cmd_info in enumerate(failure.get("commands", [])):
-                        stderr = (
-                            error_samples[i]
-                            if i < len(error_samples)
-                            else cmd_info.get("result", "")
-                        )
+                        stderr = error_samples[i] if i < len(error_samples) else cmd_info.get("result", "")
                         root_analyzer.add_command(
                             command=cmd_info.get("command", ""),
                             exit_code=1,  # These are failures
@@ -627,9 +576,7 @@ class TranscriptAnalyzer:
                         )
 
                     # If resolution was found, add the successful command
-                    if failure.get("resolution_found") and failure.get(
-                        "resolution_command"
-                    ):
+                    if failure.get("resolution_found") and failure.get("resolution_command"):
                         root_analyzer.add_command(
                             command=failure["resolution_command"],
                             exit_code=0,  # Success
@@ -668,9 +615,7 @@ class TranscriptAnalyzer:
                                 action = f"verify which flags are appropriate for {base_cmd} - tried: {flags_str}"
                             else:
                                 title = f"Fix {base_cmd} flag usage"
-                                action = self._analyze_command_variations(
-                                    commands, base_cmd, failure["occurrences"]
-                                )
+                                action = self._analyze_command_variations(commands, base_cmd, failure["occurrences"])
                             confidence = 0.80
 
                         elif variation_type == "argument_iteration":
@@ -685,9 +630,7 @@ class TranscriptAnalyzer:
 
                         else:
                             title = f"Fix repeated {base_cmd} failures"
-                            action = self._analyze_command_variations(
-                                commands, base_cmd, failure["occurrences"]
-                            )
+                            action = self._analyze_command_variations(commands, base_cmd, failure["occurrences"])
                             confidence = 0.70
 
                         candidate = {
@@ -721,9 +664,7 @@ class CandidateAggregator:
     def __init__(self, analyze_transcript: bool = True):
         self.fingerprinter = Fingerprinter()
         self.config = self._load_config()
-        self.min_evidence = self.config.get(
-            "min_evidence_count", 1
-        )  # Lowered for failures
+        self.min_evidence = self.config.get("min_evidence_count", 1)  # Lowered for failures
         # LLM analysis now done by Claude Code at /coach:review time
         self.transcript_analyzer = TranscriptAnalyzer() if analyze_transcript else None
 
@@ -762,9 +703,7 @@ class CandidateAggregator:
 
         conn = sqlite3.connect(EVENTS_DB)
         placeholders = ",".join(["?" for _ in event_ids])
-        conn.execute(
-            f"UPDATE events SET processed = 1 WHERE id IN ({placeholders})", event_ids
-        )
+        conn.execute(f"UPDATE events SET processed = 1 WHERE id IN ({placeholders})", event_ids)
         conn.commit()
         conn.close()
 
@@ -814,9 +753,7 @@ class CandidateAggregator:
                 "evidence": [
                     {
                         "event_id": e["id"],
-                        "command": json.loads(e.get("content", "{}")).get(
-                            "command", ""
-                        )[:100],
+                        "command": json.loads(e.get("content", "{}")).get("command", "")[:100],
                     }
                     for e in cmd_events[:3]
                 ],
@@ -837,13 +774,7 @@ class CandidateAggregator:
         """Extract specific trigger/action from failure patterns."""
         stderr_lower = stderr.lower()
         cmd_parts = command.split()
-        base_cmd = (
-            " ".join(cmd_parts[:2])
-            if len(cmd_parts) >= 2
-            else cmd_parts[0]
-            if cmd_parts
-            else "command"
-        )
+        base_cmd = " ".join(cmd_parts[:2]) if len(cmd_parts) >= 2 else cmd_parts[0] if cmd_parts else "command"
 
         # GitHub/Git specific patterns
         if "gh pr merge" in command:
@@ -881,9 +812,7 @@ class CandidateAggregator:
             if "ext-" in stderr_lower or "ignore-platform-req" in stderr_lower:
                 # Extract missing extensions
                 ext_matches = re.findall(r"ext-(\w+)", stderr_lower)
-                extensions = (
-                    ", ".join(ext_matches) if ext_matches else "required extensions"
-                )
+                extensions = ", ".join(ext_matches) if ext_matches else "required extensions"
                 return (
                     f"when composer fails due to missing PHP extensions ({extensions})",
                     "install missing PHP extensions or use --ignore-platform-req flags for development",
@@ -912,9 +841,7 @@ class CandidateAggregator:
                 "rule",
             )
 
-        if any(
-            code in stderr_lower for code in ["401", "403", "unauthorized", "forbidden"]
-        ):
+        if any(code in stderr_lower for code in ["401", "403", "unauthorized", "forbidden"]):
             return (
                 f"when {base_cmd} fails with authentication error",
                 "verify credentials/tokens are valid and have required permissions",
@@ -965,10 +892,7 @@ class CandidateAggregator:
         trigger = self._infer_trigger_from_context(user_message, context)
         action = self._infer_action(user_message)
 
-        if (
-            trigger == "when performing this action"
-            and action == "follow the correct procedure"
-        ):
+        if trigger == "when performing this action" and action == "follow the correct procedure":
             # Too vague, skip
             return None
 
@@ -978,10 +902,7 @@ class CandidateAggregator:
             "candidate_type": "rule",
             "trigger": trigger,
             "action": action,
-            "evidence": [
-                {"event_id": e["id"], "quote": e.get("content", "")[:100]}
-                for e in events[:5]
-            ],
+            "evidence": [{"event_id": e["id"], "quote": e.get("content", "")[:100]} for e in events[:5]],
             "confidence": min(0.5 + (len(events) * 0.1), 0.95),
             "status": "pending",
             "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1013,11 +934,7 @@ class CandidateAggregator:
             return "when editing generated files"
 
         if "don't" in message_lower or "stop" in message_lower:
-            parts = (
-                message_lower.split("don't")
-                if "don't" in message_lower
-                else message_lower.split("stop")
-            )
+            parts = message_lower.split("don't") if "don't" in message_lower else message_lower.split("stop")
             if len(parts) > 1:
                 action_part = parts[1].strip()[:50]
                 return f"when attempting to {action_part}"
@@ -1079,9 +996,7 @@ class CandidateAggregator:
         if not similar_messages:
             return None
 
-        instruction = self._extract_core_instruction(
-            similar_messages + [event.get("content", "")]
-        )
+        instruction = self._extract_core_instruction(similar_messages + [event.get("content", "")])
 
         if not instruction or len(instruction) < 10:
             return None
@@ -1092,9 +1007,7 @@ class CandidateAggregator:
             "candidate_type": "checklist",
             "trigger": "before completing tasks",
             "action": instruction,
-            "evidence": [
-                {"event_id": event["id"], "similar_count": len(similar_messages)}
-            ],
+            "evidence": [{"event_id": event["id"], "similar_count": len(similar_messages)}],
             "confidence": min(0.5 + (len(similar_messages) * 0.15), 0.9),
             "status": "pending",
             "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1126,9 +1039,7 @@ class CandidateAggregator:
                 "candidate_type": "skill",
                 "trigger": f"when using {skill_name or 'this'} skill",
                 "action": f"add guidance: {supplement_text[:200]}",
-                "evidence": [
-                    {"event_id": event["id"], "supplement": supplement_text[:100]}
-                ],
+                "evidence": [{"event_id": event["id"], "supplement": supplement_text[:100]}],
                 "confidence": 0.65,
                 "status": "pending",
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1232,9 +1143,7 @@ class CandidateAggregator:
                 "candidate_type": "snippet",  # Tool updates are snippets
                 "trigger": f"when using {tool}",
                 "action": action,
-                "evidence": [
-                    {"event_id": event["id"], "tool": tool, "matches": matches[:3]}
-                ],
+                "evidence": [{"event_id": event["id"], "tool": tool, "matches": matches[:3]}],
                 "confidence": confidence,
                 "status": "pending",
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1359,9 +1268,7 @@ class CandidateAggregator:
                 if isinstance(v, dict):
                     yield event, content, v
 
-    def _cluster_unauthorized_squash(
-        self, triples: List[Tuple[Dict, Dict, Dict]]
-    ) -> List[Dict]:
+    def _cluster_unauthorized_squash(self, triples: List[Tuple[Dict, Dict, Dict]]) -> List[Dict]:
         """Cluster unauthorized_squash violations by base command."""
         if not triples:
             return []
@@ -1376,18 +1283,12 @@ class CandidateAggregator:
 
         candidates: List[Dict] = []
         for base, members in groups.items():
-            sample_cmds = [
-                (m[2].get("command") or "")[:200]
-                for m in members
-                if m[2].get("command")
-            ]
+            sample_cmds = [(m[2].get("command") or "")[:200] for m in members if m[2].get("command")]
             repo_note = ""
             if allow_squash is True:
                 repo_note = " (repo policy allows squash merges — verify whether atomic commits are still preferred)"
             elif allow_squash is False:
-                repo_note = (
-                    " (repo policy disallows squash merges — this would fail anyway)"
-                )
+                repo_note = " (repo policy disallows squash merges — this would fail anyway)"
 
             action = (
                 f"prefer atomic commits when invoking `{base}`; only use --squash "
@@ -1420,9 +1321,7 @@ class CandidateAggregator:
             candidates.append(candidate)
         return candidates
 
-    def _cluster_cache_path_edit(
-        self, triples: List[Tuple[Dict, Dict, Dict]]
-    ) -> List[Dict]:
+    def _cluster_cache_path_edit(self, triples: List[Tuple[Dict, Dict, Dict]]) -> List[Dict]:
         """Cluster cache_path_edit violations by path-prefix."""
         if not triples:
             return []
@@ -1438,12 +1337,8 @@ class CandidateAggregator:
 
         candidates: List[Dict] = []
         for (prefix, slug), members in groups.items():
-            distinct_files = {
-                m[2].get("file_path", "") for m in members if m[2].get("file_path")
-            }
-            tools_used = sorted(
-                {m[2].get("tool", "") for m in members if m[2].get("tool")}
-            )
+            distinct_files = {m[2].get("file_path", "") for m in members if m[2].get("file_path")}
+            tools_used = sorted({m[2].get("tool", "") for m in members if m[2].get("tool")})
 
             # The slug is embedded in trigger/action so fingerprints stay unique
             # per prefix even after normalization strips the raw path.
@@ -1456,9 +1351,7 @@ class CandidateAggregator:
                 "id": str(uuid.uuid4())[:8],
                 "title": f"Do not edit files under `{prefix}`",
                 "candidate_type": "rule",
-                "trigger": (
-                    f"when editing any file under `{prefix}` (cache_prefix_{slug})"
-                ),
+                "trigger": (f"when editing any file under `{prefix}` (cache_prefix_{slug})"),
                 "action": action,
                 "evidence": [
                     {
@@ -1482,9 +1375,7 @@ class CandidateAggregator:
             candidates.append(candidate)
         return candidates
 
-    def _cluster_premature_success_claim(
-        self, triples: List[Tuple[Dict, Dict, Dict]]
-    ) -> List[Dict]:
+    def _cluster_premature_success_claim(self, triples: List[Tuple[Dict, Dict, Dict]]) -> List[Dict]:
         """Cluster premature_success_claim violations by session.
 
         The current events schema has no explicit session_id, so we approximate
@@ -1505,18 +1396,14 @@ class CandidateAggregator:
         candidates: List[Dict] = []
         for (repo_id, day), members in groups.items():
             # Collect snippets, redacting anything longer than 200 chars.
-            raw_snippets = [
-                m[2].get("snippet", "") for m in members if m[2].get("snippet")
-            ]
+            raw_snippets = [m[2].get("snippet", "") for m in members if m[2].get("snippet")]
             snippets: List[str] = []
             for s in raw_snippets[:5]:
                 if len(s) > 200:
                     snippets.append(s[:200] + "… [redacted]")
                 else:
                     snippets.append(s)
-            patterns_seen = sorted(
-                {m[2].get("pattern", "") for m in members if m[2].get("pattern")}
-            )
+            patterns_seen = sorted({m[2].get("pattern", "") for m in members if m[2].get("pattern")})
 
             action = (
                 "require command-output evidence (test runner, linter, build) "
@@ -1527,10 +1414,7 @@ class CandidateAggregator:
                 "id": str(uuid.uuid4())[:8],
                 "title": "Require evidence before success claims",
                 "candidate_type": "checklist",
-                "trigger": (
-                    "before writing 'verified' / 'tests pass' / 'should work now' "
-                    "in assistant output"
-                ),
+                "trigger": ("before writing 'verified' / 'tests pass' / 'should work now' in assistant output"),
                 "action": action,
                 "evidence": [
                     {
@@ -1555,9 +1439,7 @@ class CandidateAggregator:
             candidates.append(candidate)
         return candidates
 
-    def extract_candidate_from_process_violation(
-        self, events: List[Dict]
-    ) -> List[Dict]:
+    def extract_candidate_from_process_violation(self, events: List[Dict]) -> List[Dict]:
         """Cluster PROCESS_VIOLATION events into per-kind actionable candidates.
 
         Splits each event's inner `violations` list by `kind`, then delegates to
@@ -1574,17 +1456,9 @@ class CandidateAggregator:
             by_kind[kind].append((event, content, violation))
 
         candidates: List[Dict] = []
-        candidates.extend(
-            self._cluster_unauthorized_squash(by_kind.pop("unauthorized_squash", []))
-        )
-        candidates.extend(
-            self._cluster_cache_path_edit(by_kind.pop("cache_path_edit", []))
-        )
-        candidates.extend(
-            self._cluster_premature_success_claim(
-                by_kind.pop("premature_success_claim", [])
-            )
-        )
+        candidates.extend(self._cluster_unauthorized_squash(by_kind.pop("unauthorized_squash", [])))
+        candidates.extend(self._cluster_cache_path_edit(by_kind.pop("cache_path_edit", [])))
+        candidates.extend(self._cluster_premature_success_claim(by_kind.pop("premature_success_claim", [])))
 
         # Fallback: any remaining (unknown future) kinds get a generic pass-through
         # candidate per kind so they surface during review instead of being dropped.
@@ -1599,9 +1473,7 @@ class CandidateAggregator:
                 "candidate_type": "rule",
                 "trigger": f"when process-violation kind '{kind}' fires",
                 "action": action,
-                "evidence": [
-                    {"event_id": m[0]["id"], "violation": m[2]} for m in members[:5]
-                ],
+                "evidence": [{"event_id": m[0]["id"], "violation": m[2]} for m in members[:5]],
                 "confidence": 0.55,
                 "status": "pending",
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1637,17 +1509,13 @@ class CandidateAggregator:
 
         # Process COMMAND_FAILURE first (highest signal)
         if "COMMAND_FAILURE" in groups:
-            failure_candidates = self.extract_candidate_from_failure(
-                groups["COMMAND_FAILURE"]
-            )
+            failure_candidates = self.extract_candidate_from_failure(groups["COMMAND_FAILURE"])
             candidates.extend(failure_candidates)
             processed_ids.extend([e["id"] for e in groups["COMMAND_FAILURE"]])
 
         # Process USER_CORRECTION
         if "USER_CORRECTION" in groups:
-            candidate = self.extract_candidate_from_correction(
-                groups["USER_CORRECTION"]
-            )
+            candidate = self.extract_candidate_from_correction(groups["USER_CORRECTION"])
             if candidate:
                 candidates.append(candidate)
             processed_ids.extend([e["id"] for e in groups["USER_CORRECTION"]])
@@ -1661,33 +1529,25 @@ class CandidateAggregator:
 
         # Process SKILL_SUPPLEMENT (new: detect skill update opportunities)
         if "SKILL_SUPPLEMENT" in groups:
-            skill_candidates = self.extract_candidate_from_skill_supplement(
-                groups["SKILL_SUPPLEMENT"]
-            )
+            skill_candidates = self.extract_candidate_from_skill_supplement(groups["SKILL_SUPPLEMENT"])
             candidates.extend(skill_candidates)
             processed_ids.extend([e["id"] for e in groups["SKILL_SUPPLEMENT"]])
 
         # Process VERSION_ISSUE (new: detect outdated tools)
         if "VERSION_ISSUE" in groups:
-            version_candidates = self.extract_candidate_from_version_issue(
-                groups["VERSION_ISSUE"]
-            )
+            version_candidates = self.extract_candidate_from_version_issue(groups["VERSION_ISSUE"])
             candidates.extend(version_candidates)
             processed_ids.extend([e["id"] for e in groups["VERSION_ISSUE"]])
 
         # Process VERIFICATION_QUESTION (user asking if something was done)
         if "VERIFICATION_QUESTION" in groups:
-            verification_candidates = self.extract_candidate_from_verification(
-                groups["VERIFICATION_QUESTION"]
-            )
+            verification_candidates = self.extract_candidate_from_verification(groups["VERIFICATION_QUESTION"])
             candidates.extend(verification_candidates)
             processed_ids.extend([e["id"] for e in groups["VERIFICATION_QUESTION"]])
 
         # Process PROCESS_VIOLATION (cluster by violation kind)
         if "PROCESS_VIOLATION" in groups:
-            violation_candidates = self.extract_candidate_from_process_violation(
-                groups["PROCESS_VIOLATION"]
-            )
+            violation_candidates = self.extract_candidate_from_process_violation(groups["PROCESS_VIOLATION"])
             candidates.extend(violation_candidates)
             processed_ids.extend([e["id"] for e in groups["PROCESS_VIOLATION"]])
 
@@ -1710,9 +1570,7 @@ class CandidateAggregator:
 
         return candidates
 
-    def aggregate_with_transcript(
-        self, verbose: bool = False
-    ) -> Tuple[List[Dict], Dict]:
+    def aggregate_with_transcript(self, verbose: bool = False) -> Tuple[List[Dict], Dict]:
         """Aggregate signals AND analyze transcript for comprehensive learning."""
         # First, run normal signal aggregation
         signal_candidates = self.aggregate()
@@ -1728,11 +1586,7 @@ class CandidateAggregator:
             transcript_analysis = self.transcript_analyzer.analyze_session()
 
             if "error" not in transcript_analysis:
-                transcript_candidates = (
-                    self.transcript_analyzer.generate_candidates_from_analysis(
-                        transcript_analysis
-                    )
-                )
+                transcript_candidates = self.transcript_analyzer.generate_candidates_from_analysis(transcript_analysis)
 
                 if verbose:
                     summary = transcript_analysis.get("summary", {})
@@ -1864,9 +1718,7 @@ class CandidateAggregator:
 
             # Use UPSERT pattern to handle duplicates atomically
             # First, try to get existing repo_ids to merge them
-            cursor = conn.execute(
-                "SELECT repo_ids, count FROM candidates WHERE fingerprint = ?", (fp,)
-            )
+            cursor = conn.execute("SELECT repo_ids, count FROM candidates WHERE fingerprint = ?", (fp,))
             row = cursor.fetchone()
 
             if row:
@@ -1936,12 +1788,8 @@ def main():
     parser = argparse.ArgumentParser(description="Aggregate signals into candidates")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     parser.add_argument("--dry-run", action="store_true", help="Don't save candidates")
-    parser.add_argument(
-        "--no-transcript", action="store_true", help="Skip transcript analysis"
-    )
-    parser.add_argument(
-        "--transcript-only", action="store_true", help="Only analyze transcript"
-    )
+    parser.add_argument("--no-transcript", action="store_true", help="Skip transcript analysis")
+    parser.add_argument("--transcript-only", action="store_true", help="Only analyze transcript")
     # Note: --no-llm removed - LLM analysis now done by Claude Code at /coach:review time
 
     args = parser.parse_args()
@@ -1975,11 +1823,7 @@ def main():
                     for c in high_intensity[:3]:
                         print(f"    - {c.get('message', '')[:80]}...")
 
-            candidates = (
-                aggregator.transcript_analyzer.generate_candidates_from_analysis(
-                    analysis
-                )
-            )
+            candidates = aggregator.transcript_analyzer.generate_candidates_from_analysis(analysis)
             if candidates:
                 print(f"\nGenerated {len(candidates)} candidates from transcript")
                 for c in candidates:
@@ -1987,9 +1831,7 @@ def main():
         return 0
 
     # Full aggregation with transcript analysis
-    candidates, transcript_analysis = aggregator.aggregate_with_transcript(
-        verbose=args.verbose
-    )
+    candidates, transcript_analysis = aggregator.aggregate_with_transcript(verbose=args.verbose)
 
     if args.verbose:
         print(f"\nGenerated {len(candidates)} total candidates:")

--- a/skills/coach/scripts/apply.py
+++ b/skills/coach/scripts/apply.py
@@ -40,9 +40,7 @@ class ProposalApplier:
         """Save candidates to file."""
         CANDIDATES_FILE.write_text(json.dumps(data, indent=2))
 
-    def find_candidate(
-        self, candidate_id: str, data: Dict
-    ) -> Optional[Tuple[Dict, str]]:
+    def find_candidate(self, candidate_id: str, data: Dict) -> Optional[Tuple[Dict, str]]:
         """Find a candidate by ID prefix."""
         for status in ["pending", "approved", "rejected"]:
             for c in data.get(status, []):
@@ -100,9 +98,7 @@ class ProposalApplier:
                 result["commit"] = commit_msg
 
         # Update candidate status
-        data["pending"] = [
-            c for c in data["pending"] if c.get("id") != candidate.get("id")
-        ]
+        data["pending"] = [c for c in data["pending"] if c.get("id") != candidate.get("id")]
         candidate["status"] = "approved"
         candidate["approved_at"] = datetime.now(UTC).isoformat()
         candidate["applied_to"] = proposal.get("target_file")
@@ -128,9 +124,7 @@ class ProposalApplier:
             }
 
         # Update status
-        data["pending"] = [
-            c for c in data["pending"] if c.get("id") != candidate.get("id")
-        ]
+        data["pending"] = [c for c in data["pending"] if c.get("id") != candidate.get("id")]
         candidate["status"] = "rejected"
         candidate["rejected_at"] = datetime.now(UTC).isoformat()
         candidate["rejection_reason"] = reason
@@ -300,9 +294,7 @@ def main():
     # Approve command
     approve_parser = subparsers.add_parser("approve", help="Approve a candidate")
     approve_parser.add_argument("candidate_id", help="Candidate ID to approve")
-    approve_parser.add_argument(
-        "--no-branch", action="store_true", help="Don't create git branch"
-    )
+    approve_parser.add_argument("--no-branch", action="store_true", help="Don't create git branch")
 
     # Reject command
     reject_parser = subparsers.add_parser("reject", help="Reject a candidate")

--- a/skills/coach/scripts/detect_signals.py
+++ b/skills/coach/scripts/detect_signals.py
@@ -293,9 +293,7 @@ class SignalDetector:
                 "matches": matches,
                 "caps_words": caps_words,
                 "exclamation_count": exclamation_count,
-                "confidence": min(
-                    0.2 + (caps_words * 0.1) + (exclamation_count * 0.05), 0.8
-                ),
+                "confidence": min(0.2 + (caps_words * 0.1) + (exclamation_count * 0.05), 0.8),
                 "preceding_context": self.get_preceding_context(),
             }
         return None
@@ -336,16 +334,10 @@ class SignalDetector:
             }
         return None
 
-    def detect_command_failure(
-        self, exit_code: int, stderr: str, command: str
-    ) -> Optional[Dict]:
+    def detect_command_failure(self, exit_code: int, stderr: str, command: str) -> Optional[Dict]:
         """Detect command/tool failures with expanded patterns."""
         # Check for repeated similar failures
-        recent_failures = [
-            tc
-            for tc in self.recent_context.get("tool_calls", [])[-10:]
-            if tc.get("exit_code", 0) != 0
-        ]
+        recent_failures = [tc for tc in self.recent_context.get("tool_calls", [])[-10:] if tc.get("exit_code", 0) != 0]
 
         similar_failures = []
         for f in recent_failures:
@@ -423,9 +415,7 @@ class SignalDetector:
         for pattern in self.patterns.get("verification_question", []):
             match = pattern.search(content)
             if match:
-                matches.append(
-                    {"pattern": pattern.pattern, "matched_text": match.group(0)}
-                )
+                matches.append({"pattern": pattern.pattern, "matched_text": match.group(0)})
 
         if matches:
             # Extract what action was being verified
@@ -593,16 +583,12 @@ class SignalDetector:
         # Check for skill supplementation
         skill_supplement = self.detect_skill_supplement(content)
         if skill_supplement:
-            signals.append(
-                {**skill_supplement, "content": content[:500], "context": context}
-            )
+            signals.append({**skill_supplement, "content": content[:500], "context": context})
 
         # Check for verification questions (user asking if something was done)
         verification = self.detect_verification_question(content)
         if verification:
-            signals.append(
-                {**verification, "content": content[:500], "context": context}
-            )
+            signals.append({**verification, "content": content[:500], "context": context})
 
         return signals
 
@@ -706,15 +692,11 @@ def main():
         required=True,
         help="Processing phase (pre=user, tool=tool result, stop=end of assistant turn)",
     )
-    parser.add_argument(
-        "--content", type=str, help="Message content (or read from stdin)"
-    )
+    parser.add_argument("--content", type=str, help="Message content (or read from stdin)")
     parser.add_argument("--exit-code", type=int, default=None, help="Tool exit code")
     parser.add_argument("--stderr", type=str, default="", help="Tool stderr")
     parser.add_argument("--command", type=str, default="", help="Tool command")
-    parser.add_argument(
-        "--from-stdin", action="store_true", help="Read JSON data from stdin"
-    )
+    parser.add_argument("--from-stdin", action="store_true", help="Read JSON data from stdin")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
 
     args = parser.parse_args()
@@ -736,9 +718,7 @@ def main():
                     tool_name = data.get("tool_name", "")
 
                     exit_code = tool_result.get("exit_code", 0)
-                    stderr = tool_result.get("stderr", "") or tool_result.get(
-                        "output", ""
-                    )
+                    stderr = tool_result.get("stderr", "") or tool_result.get("output", "")
                     command = tool_input.get("command", "")
                     file_path = tool_input.get("file_path", "")
 
@@ -768,14 +748,10 @@ def main():
                     # produced in the same turn; if any tool output is present,
                     # claims are considered substantiated.
                     assistant_text = (
-                        data.get("assistant_text", "")
-                        or data.get("content", "")
-                        or data.get("message", "")
+                        data.get("assistant_text", "") or data.get("content", "") or data.get("message", "")
                     )
                     turn_tool_outputs = data.get("turn_tool_outputs", []) or []
-                    has_output = bool(turn_tool_outputs) or bool(
-                        data.get("has_preceding_tool_output")
-                    )
+                    has_output = bool(turn_tool_outputs) or bool(data.get("has_preceding_tool_output"))
                     violation = detector.detect_process_violation(
                         assistant_text=assistant_text,
                         has_preceding_tool_output=has_output,
@@ -794,17 +770,13 @@ def main():
     elif args.phase == "pre" and args.content:
         signals = detector.process_user_message(args.content)
     elif args.phase == "tool" and args.exit_code is not None:
-        signals = detector.process_tool_result(
-            args.exit_code, args.stderr, args.command
-        )
+        signals = detector.process_tool_result(args.exit_code, args.stderr, args.command)
 
     # Store detected signals
     for signal in signals:
         event_id = store_signal(signal, args.phase)
         if args.verbose and event_id:
-            print(
-                f"Stored signal {event_id}: {signal['signal_type']} (confidence: {signal.get('confidence', 0):.2f})"
-            )
+            print(f"Stored signal {event_id}: {signal['signal_type']} (confidence: {signal.get('confidence', 0):.2f})")
 
     if args.verbose:
         print(f"Detected {len(signals)} signals")

--- a/skills/coach/scripts/fingerprint.py
+++ b/skills/coach/scripts/fingerprint.py
@@ -61,9 +61,7 @@ TOOL_BUCKETS = {
 class Fingerprinter:
     """Generate stable fingerprints for candidate deduplication."""
 
-    def __init__(
-        self, custom_rules: List[tuple] = None, custom_buckets: Dict[str, str] = None
-    ):
+    def __init__(self, custom_rules: List[tuple] = None, custom_buckets: Dict[str, str] = None):
         self.rules = NORMALIZATION_RULES + (custom_rules or [])
         self.buckets = {**TOOL_BUCKETS, **(custom_buckets or {})}
 
@@ -77,9 +75,7 @@ class Fingerprinter:
 
         # Apply tool bucket replacements
         for tool, bucket in self.buckets.items():
-            result = re.sub(
-                rf"\b{re.escape(tool)}\b", bucket, result, flags=re.IGNORECASE
-            )
+            result = re.sub(rf"\b{re.escape(tool)}\b", bucket, result, flags=re.IGNORECASE)
 
         # Apply normalization rules
         for pattern, replacement in self.rules:
@@ -106,9 +102,7 @@ class Fingerprinter:
     def fingerprint(self, candidate_type: str, trigger: str, action: str) -> str:
         """Generate SHA-256 fingerprint for a candidate."""
         # Combine and normalize components
-        combined = (
-            f"{candidate_type}|{self.normalize(trigger)}|{self.normalize(action)}"
-        )
+        combined = f"{candidate_type}|{self.normalize(trigger)}|{self.normalize(action)}"
 
         # Generate hash
         return hashlib.sha256(combined.encode()).hexdigest()
@@ -134,14 +128,10 @@ class Fingerprinter:
 
         return intersection / union if union > 0 else 0.0
 
-    def is_similar(
-        self, candidate1: Dict, candidate2: Dict, threshold: float = 0.6
-    ) -> bool:
+    def is_similar(self, candidate1: Dict, candidate2: Dict, threshold: float = 0.6) -> bool:
         """Check if two candidates are similar enough to be considered duplicates."""
         # Same fingerprint = identical
-        if self.fingerprint_candidate(candidate1) == self.fingerprint_candidate(
-            candidate2
-        ):
+        if self.fingerprint_candidate(candidate1) == self.fingerprint_candidate(candidate2):
             return True
 
         # Check type match first
@@ -176,9 +166,7 @@ def main():
     parser.add_argument("--type", required=True, help="Candidate type")
     parser.add_argument("--trigger", required=True, help="Trigger condition")
     parser.add_argument("--action", required=True, help="Action to take")
-    parser.add_argument(
-        "--show-normalized", action="store_true", help="Show normalized text"
-    )
+    parser.add_argument("--show-normalized", action="store_true", help="Show normalized text")
 
     args = parser.parse_args()
 

--- a/skills/coach/scripts/hook_healer.py
+++ b/skills/coach/scripts/hook_healer.py
@@ -95,9 +95,7 @@ def update_settings_hooks() -> bool:
     updated = False
 
     # Pattern to match versioned coach plugin paths
-    version_pattern = re.compile(
-        r"python3\s+.*?plugins/cache/[^/]+/coach/[^/]+/skills/coach/scripts/(\w+\.py)"
-    )
+    version_pattern = re.compile(r"python3\s+.*?plugins/cache/[^/]+/coach/[^/]+/skills/coach/scripts/(\w+\.py)")
 
     def update_command(cmd: str) -> str:
         """Replace versioned path with stable launcher using async mode."""

--- a/skills/coach/scripts/init_coach.py
+++ b/skills/coach/scripts/init_coach.py
@@ -217,9 +217,7 @@ def update_settings_hooks() -> bool:
     # Pattern to match versioned coach plugin paths
     import re
 
-    version_pattern = re.compile(
-        r"python3\s+.*?plugins/cache/[^/]+/coach/[^/]+/skills/coach/scripts/(\w+\.py)"
-    )
+    version_pattern = re.compile(r"python3\s+.*?plugins/cache/[^/]+/coach/[^/]+/skills/coach/scripts/(\w+\.py)")
 
     def update_command(cmd: str) -> str:
         """Replace versioned path with stable launcher using async mode."""
@@ -289,9 +287,7 @@ def init_coach(force: bool = False) -> int:
 
     # Initialize candidates file
     if not CANDIDATES_FILE.exists() or force:
-        CANDIDATES_FILE.write_text(
-            json.dumps({"pending": [], "last_proposal": None}, indent=2)
-        )
+        CANDIDATES_FILE.write_text(json.dumps({"pending": [], "last_proposal": None}, indent=2))
         print(f"  Created candidates file: {CANDIDATES_FILE}")
     else:
         print(f"  Candidates file exists: {CANDIDATES_FILE}")
@@ -318,9 +314,7 @@ def init_coach(force: bool = False) -> int:
     if install_launcher():
         update_settings_hooks()
     else:
-        print(
-            "  Warning: Could not install launcher, hooks may break on version updates"
-        )
+        print("  Warning: Could not install launcher, hooks may break on version updates")
 
     print("\nCoach system initialized successfully!")
     print("\nNext steps:")
@@ -334,12 +328,8 @@ def init_coach(force: bool = False) -> int:
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Initialize Coach self-learning system"
-    )
-    parser.add_argument(
-        "--force", "-f", action="store_true", help="Reinitialize even if files exist"
-    )
+    parser = argparse.ArgumentParser(description="Initialize Coach self-learning system")
+    parser.add_argument("--force", "-f", action="store_true", help="Reinitialize even if files exist")
     args = parser.parse_args()
 
     sys.exit(init_coach(force=args.force))

--- a/skills/coach/scripts/ledger.py
+++ b/skills/coach/scripts/ledger.py
@@ -51,9 +51,7 @@ class Ledger:
     def get_candidate(self, fingerprint: str) -> Optional[Dict]:
         """Get a candidate by fingerprint."""
         conn = self._connect()
-        cursor = conn.execute(
-            "SELECT * FROM candidates WHERE fingerprint = ?", (fingerprint,)
-        )
+        cursor = conn.execute("SELECT * FROM candidates WHERE fingerprint = ?", (fingerprint,))
         row = cursor.fetchone()
         conn.close()
 
@@ -203,9 +201,7 @@ class Ledger:
             FROM candidates
             GROUP BY status
         """)
-        stats["by_status"] = {
-            row["status"] or "unknown": row["count"] for row in cursor.fetchall()
-        }
+        stats["by_status"] = {row["status"] or "unknown": row["count"] for row in cursor.fetchall()}
 
         # Multi-repo candidates
         cursor = conn.execute("""
@@ -316,12 +312,8 @@ def main():
     check_parser.add_argument("fingerprint", help="Candidate fingerprint")
 
     # Cleanup command
-    cleanup_parser = subparsers.add_parser(
-        "cleanup", help="Clean old rejected candidates"
-    )
-    cleanup_parser.add_argument(
-        "--days", type=int, default=90, help="Age threshold in days"
-    )
+    cleanup_parser = subparsers.add_parser("cleanup", help="Clean old rejected candidates")
+    cleanup_parser.add_argument("--days", type=int, default=90, help="Age threshold in days")
 
     args = parser.parse_args()
 

--- a/skills/coach/scripts/propose.py
+++ b/skills/coach/scripts/propose.py
@@ -131,20 +131,14 @@ class ProposalGenerator:
             if old_content:
                 combined = old_content.rstrip() + "\n\n" + new_content.strip() + "\n"
             else:
-                header = (
-                    "# AGENTS.md"
-                    if target_file.name == "AGENTS.md"
-                    else "# Claude Code Instructions"
-                )
+                header = "# AGENTS.md" if target_file.name == "AGENTS.md" else "# Claude Code Instructions"
                 combined = f"{header}\n\n{new_content.strip()}\n"
         else:
             # For standalone files, use new content
             combined = new_content.strip() + "\n"
 
         # Generate unified diff
-        diff_lines = self._generate_unified_diff(
-            str(target_file), old_content, combined
-        )
+        diff_lines = self._generate_unified_diff(str(target_file), old_content, combined)
 
         return {
             "candidate_id": candidate.get("id", ""),
@@ -289,7 +283,9 @@ class ProposalGenerator:
             display += f"│ {line[:47]:<47} │\n"
 
         if len(proposal.get("diff", "").split("\n")) > 10:
-            display += f"│ ... ({len(proposal.get('diff', '').split(chr(10))) - 10} more lines)                           │\n"
+            display += (
+                f"│ ... ({len(proposal.get('diff', '').split(chr(10))) - 10} more lines)                           │\n"
+            )
 
         display += """└─────────────────────────────────────────────────┘
 
@@ -310,9 +306,7 @@ def main():
     parser = argparse.ArgumentParser(description="Generate proposal for candidate")
     parser.add_argument("--candidate-id", help="Specific candidate ID to process")
     parser.add_argument("--scope", choices=["project", "global"], help="Override scope")
-    parser.add_argument(
-        "--display", action="store_true", help="Display formatted proposal"
-    )
+    parser.add_argument("--display", action="store_true", help="Display formatted proposal")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     args = parser.parse_args()

--- a/skills/coach/scripts/root_cause_analyzer.py
+++ b/skills/coach/scripts/root_cause_analyzer.py
@@ -284,9 +284,7 @@ class RootCauseAnalyzer:
     def __init__(self):
         self.sequences: Dict[str, CommandSequence] = {}
 
-    def add_command(
-        self, command: str, exit_code: int, stderr: str, timestamp: str = None
-    ):
+    def add_command(self, command: str, exit_code: int, stderr: str, timestamp: str = None):
         """Add a command execution to the analysis."""
         variation = CommandVariation(
             command=command,
@@ -357,15 +355,11 @@ class RootCauseAnalyzer:
         # If resolved, extract what worked
         if sequence.eventually_succeeded:
             analysis["resolution"] = self._extract_resolution(sequence)
-            analysis["actionable_insight"] = self._generate_actionable_insight(
-                sequence, analysis
-            )
+            analysis["actionable_insight"] = self._generate_actionable_insight(sequence, analysis)
         else:
             # Still failing - analyze common error patterns
             analysis["root_cause"] = self._identify_root_cause(sequence)
-            analysis["actionable_insight"] = self._generate_failure_insight(
-                sequence, analysis
-            )
+            analysis["actionable_insight"] = self._generate_failure_insight(sequence, analysis)
 
         return analysis
 
@@ -492,9 +486,7 @@ class RootCauseAnalyzer:
         # Check against known command issues
         for cmd_pattern, knowledge in self.COMMAND_KNOWLEDGE.items():
             if cmd_pattern in base_cmd:
-                for error_pattern, solution in knowledge.get(
-                    "common_issues", {}
-                ).items():
+                for error_pattern, solution in knowledge.get("common_issues", {}).items():
                     for err in errors:
                         if error_pattern.lower() in err.lower():
                             return {
@@ -532,9 +524,7 @@ class RootCauseAnalyzer:
             "evidence": errors[0][:200] if errors else "No error message captured",
         }
 
-    def _generate_actionable_insight(
-        self, sequence: CommandSequence, analysis: Dict
-    ) -> Dict:
+    def _generate_actionable_insight(self, sequence: CommandSequence, analysis: Dict) -> Dict:
         """Generate a specific actionable insight from successful resolution."""
         resolution = analysis.get("resolution", {})
         res_type = resolution.get("type", "unknown")
@@ -585,9 +575,7 @@ class RootCauseAnalyzer:
 
         return None
 
-    def _generate_failure_insight(
-        self, sequence: CommandSequence, analysis: Dict
-    ) -> Dict:
+    def _generate_failure_insight(self, sequence: CommandSequence, analysis: Dict) -> Dict:
         """Generate insight for still-failing commands."""
         root_cause = analysis.get("root_cause", {})
         cause_type = root_cause.get("type", "unknown")
@@ -717,9 +705,7 @@ def test_compound_command_parsing():
 
     for cmd, expected in tests:
         result = split_compound_command(cmd)
-        assert result == expected, (
-            f"split_compound_command('{cmd}'): expected {expected}, got {result}"
-        )
+        assert result == expected, f"split_compound_command('{cmd}'): expected {expected}, got {result}"
         print(f"  ✓ split: '{cmd[:40]}...' -> {len(result)} parts")
 
     # Test strip_env_var_prefix
@@ -733,9 +719,7 @@ def test_compound_command_parsing():
 
     for cmd, expected in tests:
         result = strip_env_var_prefix(cmd)
-        assert result == expected, (
-            f"strip_env_var_prefix('{cmd}'): expected '{expected}', got '{result}'"
-        )
+        assert result == expected, f"strip_env_var_prefix('{cmd}'): expected '{expected}', got '{result}'"
         print(f"  ✓ strip_env: '{cmd[:40]}...' -> '{result[:40]}'")
 
     # Test extract_primary_command
@@ -760,9 +744,7 @@ def test_compound_command_parsing():
 
     for cmd, expected in tests:
         result = extract_primary_command(cmd)
-        assert result == expected, (
-            f"extract_primary_command('{cmd}'): expected '{expected}', got '{result}'"
-        )
+        assert result == expected, f"extract_primary_command('{cmd}'): expected '{expected}', got '{result}'"
         print(f"  ✓ primary: '{cmd[:40]}...' -> '{result[:40]}'")
 
     # Test get_base_executable
@@ -782,9 +764,7 @@ def test_compound_command_parsing():
 
     for cmd, expected in tests:
         result = get_base_executable(cmd)
-        assert result == expected, (
-            f"get_base_executable('{cmd}'): expected '{expected}', got '{result}'"
-        )
+        assert result == expected, f"get_base_executable('{cmd}'): expected '{expected}', got '{result}'"
         print(f"  ✓ base: '{cmd[:40]}...' -> '{result}'")
 
     print("\n✓ All compound command parsing tests passed!\n")
@@ -802,18 +782,14 @@ def test_analyzer_skips_blacklisted():
     analyzer.add_command("echo hello", exit_code=0, stderr="")
 
     # These should be skipped (base_command is empty)
-    assert len(analyzer.sequences) == 0, (
-        f"Expected 0 sequences, got {len(analyzer.sequences)}"
-    )
+    assert len(analyzer.sequences) == 0, f"Expected 0 sequences, got {len(analyzer.sequences)}"
     print("  ✓ Blacklisted-only commands skipped")
 
     # Add commands with real executables
     analyzer.add_command("cd /path && phpunit --test", exit_code=1, stderr="failed")
     analyzer.add_command("cd /path && phpunit --test --verbose", exit_code=0, stderr="")
 
-    assert "phpunit" in analyzer.sequences, (
-        f"Expected 'phpunit' in sequences, got {list(analyzer.sequences.keys())}"
-    )
+    assert "phpunit" in analyzer.sequences, f"Expected 'phpunit' in sequences, got {list(analyzer.sequences.keys())}"
     print("  ✓ Compound commands properly extract phpunit")
 
     # Verify the base_command is 'phpunit', not 'cd /path'
@@ -853,12 +829,8 @@ def test_diff_uses_primary_command():
     # Should have insight for phpunit, not cd
     for insight in insights:
         base_cmd = insight.get("analysis", {}).get("base_command", "")
-        assert "cd" not in base_cmd, (
-            f"Base command should not contain 'cd', got '{base_cmd}'"
-        )
-        assert "phpunit" in base_cmd, (
-            f"Base command should contain 'phpunit', got '{base_cmd}'"
-        )
+        assert "cd" not in base_cmd, f"Base command should not contain 'cd', got '{base_cmd}'"
+        assert "phpunit" in base_cmd, f"Base command should contain 'phpunit', got '{base_cmd}'"
         print(f"  ✓ Insight base_command: '{base_cmd}'")
 
     print("\n✓ All diff tests passed!\n")
@@ -868,9 +840,7 @@ def main():
     """Test the analyzer with sample data."""
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Analyze command sequences for root causes"
-    )
+    parser = argparse.ArgumentParser(description="Analyze command sequences for root causes")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     parser.add_argument("--context-file", help="Load from recent_context.json")
     parser.add_argument("--test", action="store_true", help="Run unit tests")

--- a/skills/coach/scripts/scope_analyzer.py
+++ b/skills/coach/scripts/scope_analyzer.py
@@ -140,9 +140,7 @@ class ScopeAnalyzer:
         if global_claude_md.exists():
             content = global_claude_md.read_text(encoding="utf-8")
             # Simple similarity check
-            candidate_text = (
-                f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
-            )
+            candidate_text = f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
             if fp.similarity(candidate_text, content) > 0.4:
                 result["exists_global"] = True
 
@@ -150,9 +148,7 @@ class ScopeAnalyzer:
         project_rules_md = repo_root() / "AGENTS.md"
         if project_rules_md.exists():
             content = project_rules_md.read_text(encoding="utf-8")
-            candidate_text = (
-                f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
-            )
+            candidate_text = f"{candidate.get('trigger', '')} {candidate.get('action', '')}"
             if fp.similarity(candidate_text, content) > 0.4:
                 result["exists_project"] = True
 
@@ -195,49 +191,35 @@ class ScopeAnalyzer:
         # Rule 1: If exists globally, prefer global (dedupe)
         if existing["exists_global"]:
             recommended_scope = "global"
-            recommendation_reason.append(
-                "Similar rule exists globally - update instead of duplicate"
-            )
+            recommendation_reason.append("Similar rule exists globally - update instead of duplicate")
 
         # Rule 2: If only exists in project, keep in project (consistency)
         elif existing["exists_project"]:
             recommended_scope = "project"
-            recommendation_reason.append(
-                "Similar rule exists in project - maintain consistency"
-            )
+            recommendation_reason.append("Similar rule exists in project - maintain consistency")
 
         # Rule 3: Cross-repo threshold
         elif cross_repo["repo_count"] >= self.promotion_threshold:
             recommended_scope = "global"
-            recommendation_reason.append(
-                f"Seen in {cross_repo['repo_count']} repos - promote to global"
-            )
+            recommendation_reason.append(f"Seen in {cross_repo['repo_count']} repos - promote to global")
 
         # Rule 4: Score-based decision
         elif global_score > project_score * 1.5:
             recommended_scope = "global"
-            recommendation_reason.append(
-                f"Global indicators strong ({global_score:.1f} vs {project_score:.1f})"
-            )
+            recommendation_reason.append(f"Global indicators strong ({global_score:.1f} vs {project_score:.1f})")
 
         elif project_score > global_score * 1.5:
             recommended_scope = "project"
-            recommendation_reason.append(
-                f"Project indicators strong ({project_score:.1f} vs {global_score:.1f})"
-            )
+            recommendation_reason.append(f"Project indicators strong ({project_score:.1f} vs {global_score:.1f})")
 
         else:
             # Ambiguous - default to project
             recommended_scope = "project"
-            recommendation_reason.append(
-                "Scores ambiguous - defaulting to project scope"
-            )
+            recommendation_reason.append("Scores ambiguous - defaulting to project scope")
 
         # Promotion eligibility
         eligible_for_promotion = (
-            recommended_scope == "project"
-            and cross_repo["repo_count"] >= 1
-            and global_score >= project_score * 0.8
+            recommended_scope == "project" and cross_repo["repo_count"] >= 1 and global_score >= project_score * 0.8
         )
 
         return {
@@ -297,9 +279,7 @@ def main():
     else:
         print(f"Recommended scope: {result['recommended_scope']}")
         print(f"Reasons: {', '.join(result['recommendation_reasons'])}")
-        print(
-            f"Scores: project={result['project_score']:.1f}, global={result['global_score']:.1f}"
-        )
+        print(f"Scores: project={result['project_score']:.1f}, global={result['global_score']:.1f}")
         if result["eligible_for_promotion"]:
             print("Eligible for promotion to global")
 

--- a/skills/coach/scripts/skill_analyzer.py
+++ b/skills/coach/scripts/skill_analyzer.py
@@ -48,12 +48,8 @@ class SkillAnalyzer:
     ]
 
     def __init__(self):
-        self.supplement_patterns = [
-            re.compile(p, re.IGNORECASE) for p in self.SKILL_SUPPLEMENT_PATTERNS
-        ]
-        self.reference_patterns = [
-            re.compile(p, re.IGNORECASE) for p in self.SKILL_REFERENCE_PATTERNS
-        ]
+        self.supplement_patterns = [re.compile(p, re.IGNORECASE) for p in self.SKILL_SUPPLEMENT_PATTERNS]
+        self.reference_patterns = [re.compile(p, re.IGNORECASE) for p in self.SKILL_REFERENCE_PATTERNS]
 
     def get_installed_skills(self) -> Dict[str, Path]:
         """Get list of installed skills."""
@@ -79,9 +75,7 @@ class SkillAnalyzer:
 
         return skills
 
-    def detect_skill_supplement(
-        self, user_message: str, context: Dict
-    ) -> Optional[Dict]:
+    def detect_skill_supplement(self, user_message: str, context: Dict) -> Optional[Dict]:
         """Detect if user is supplementing a skill with additional instructions."""
         message_lower = user_message.lower()
 
@@ -121,9 +115,7 @@ class SkillAnalyzer:
 
         return None
 
-    def analyze_skill_for_updates(
-        self, skill_path: Path, failure_patterns: List[Dict]
-    ) -> List[Dict]:
+    def analyze_skill_for_updates(self, skill_path: Path, failure_patterns: List[Dict]) -> List[Dict]:
         """Analyze a skill for potential updates based on failure patterns."""
         candidates = []
 
@@ -159,9 +151,7 @@ class SkillAnalyzer:
 
         return candidates
 
-    def generate_skill_update_candidate(
-        self, skill_name: str, supplement: str, context: Dict
-    ) -> Optional[Dict]:
+    def generate_skill_update_candidate(self, skill_name: str, supplement: str, context: Dict) -> Optional[Dict]:
         """Generate a candidate to update a skill based on user supplement."""
         if not skill_name:
             return None
@@ -231,9 +221,7 @@ class OutdatedToolAnalyzer:
     }
 
     def __init__(self):
-        self.version_patterns = [
-            (re.compile(p, re.IGNORECASE), t) for p, t in self.VERSION_ISSUE_PATTERNS
-        ]
+        self.version_patterns = [(re.compile(p, re.IGNORECASE), t) for p, t in self.VERSION_ISSUE_PATTERNS]
 
     def detect_version_issue(self, stderr: str, command: str) -> Optional[Dict]:
         """Detect version-related issues from stderr output."""
@@ -258,9 +246,7 @@ class OutdatedToolAnalyzer:
         min_version = self.MIN_VERSIONS.get(tool)
 
         try:
-            result = subprocess.run(
-                cmd.split(), capture_output=True, text=True, timeout=5
-            )
+            result = subprocess.run(cmd.split(), capture_output=True, text=True, timeout=5)
             output = result.stdout + result.stderr
             match = re.search(version_pattern, output)
 
@@ -363,9 +349,7 @@ class OutdatedToolAnalyzer:
 
         candidate = {
             "id": f"tool-{tool[:6]}-{hash(str(tool_info)) % 10000:04d}",
-            "title": f"Update {tool}"
-            if status != "not_installed"
-            else f"Install {tool}",
+            "title": f"Update {tool}" if status != "not_installed" else f"Install {tool}",
             "candidate_type": "snippet",
             "trigger": trigger,
             "action": action,
@@ -378,9 +362,7 @@ class OutdatedToolAnalyzer:
         candidate["fingerprint"] = fingerprint_candidate(candidate)
         return candidate
 
-    def scan_project_dependencies(
-        self, project_path: Path = None
-    ) -> Tuple[List[Dict], List[Dict]]:
+    def scan_project_dependencies(self, project_path: Path = None) -> Tuple[List[Dict], List[Dict]]:
         """Scan project for outdated dependencies."""
         cwd = project_path or Path.cwd()
         candidates = []
@@ -422,9 +404,7 @@ class CombinedAnalyzer:
         self.skill_analyzer = SkillAnalyzer()
         self.tool_analyzer = OutdatedToolAnalyzer()
 
-    def analyze_stderr_for_issues(
-        self, command: str, stderr: str, exit_code: int
-    ) -> List[Dict]:
+    def analyze_stderr_for_issues(self, command: str, stderr: str, exit_code: int) -> List[Dict]:
         """Analyze command stderr for skill/tool issues."""
         candidates = []
 
@@ -444,9 +424,7 @@ class CombinedAnalyzer:
 
         return candidates
 
-    def analyze_user_message_for_skills(
-        self, user_message: str, context: Dict
-    ) -> List[Dict]:
+    def analyze_user_message_for_skills(self, user_message: str, context: Dict) -> List[Dict]:
         """Analyze user message for skill improvement opportunities."""
         candidates = []
 
@@ -454,9 +432,7 @@ class CombinedAnalyzer:
         supplement = self.skill_analyzer.detect_skill_supplement(user_message, context)
         if supplement:
             skill_name = supplement.get("skill_name")
-            candidate = self.skill_analyzer.generate_skill_update_candidate(
-                skill_name, user_message, context
-            )
+            candidate = self.skill_analyzer.generate_skill_update_candidate(skill_name, user_message, context)
             if candidate:
                 candidates.append(candidate)
 
@@ -511,9 +487,7 @@ def main():
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     parser.add_argument("--scan", action="store_true", help="Run full dependency scan")
     parser.add_argument("--check-tool", type=str, help="Check specific tool version")
-    parser.add_argument(
-        "--list-skills", action="store_true", help="List installed skills"
-    )
+    parser.add_argument("--list-skills", action="store_true", help="List installed skills")
 
     args = parser.parse_args()
 

--- a/skills/coach/scripts/tests/test_process_violation_clustering.py
+++ b/skills/coach/scripts/tests/test_process_violation_clustering.py
@@ -27,9 +27,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from aggregate import CandidateAggregator  # noqa: E402
 
 
-def _make_event(
-    event_id: str, violations, repo_id="repo-a", timestamp="2026-04-18T09:00:00Z"
-):
+def _make_event(event_id: str, violations, repo_id="repo-a", timestamp="2026-04-18T09:00:00Z"):
     """Build a minimal event row matching the events table shape."""
     return {
         "id": event_id,
@@ -92,12 +90,8 @@ class ProcessViolationClusteringTests(unittest.TestCase):
 
         # Force repo-policy lookup to a known value so the test is deterministic
         # regardless of the cwd gh happens to see.
-        with patch.object(
-            CandidateAggregator, "_repo_allows_squash", staticmethod(lambda: False)
-        ):
-            candidates = self.aggregator.extract_candidate_from_process_violation(
-                events
-            )
+        with patch.object(CandidateAggregator, "_repo_allows_squash", staticmethod(lambda: False)):
+            candidates = self.aggregator.extract_candidate_from_process_violation(events)
 
         self.assertEqual(len(candidates), 2, candidates)
         kinds = {c["violation_kind"] for c in candidates}


### PR DESCRIPTION
Final release. Delta since v2.5.3: packaging fix relocating scripts/references under skills/coach and space-safe versioned plugin cache paths (#33), Verification field in rule/antipattern templates (#32), deprecation notice in favor of retro-skill (#34). Also adds the Agent Plugins 1.0.0 portable root manifest, which the skill validator now requires. The repo is re-archived after this release.